### PR TITLE
Unit tests for the physical distance sensor

### DIFF
--- a/distance/Distance_Sensor_Physical.py
+++ b/distance/Distance_Sensor_Physical.py
@@ -1,5 +1,5 @@
 import time
-import RPi.GPIO as gpio
+import RPi.GPIO
 from ..settings import Settings
 from Distance_Sensor import Distance_Sensor
 
@@ -7,41 +7,45 @@ class Distance_Sensor_Physical(Distance_Sensor):
     def __init__(self):
         self.settings = Settings("settings.json", "distance_sensor_physical")
 
-        # Disable warnings about pins being in use
-        gpio.setwarnings(False)
+        # Initialize the RPi.GPIO module. Doing it this way instead of using
+        # an alias during import allows unit tests to access it too.
+        self.gpio = RPi.GPIO()
 
-        # Use board numbering which corresponds to the
-        # pin numbers on the P1 header of the board.
-        gpio.setmode(gpio.BOARD)
+        # Disable warnings about pins being in use.
+        self.gpio.setwarnings(False)
 
-        # Configure the input and output pins
-        gpio.setup(self.settings.get("trigger_pin"), gpio.OUT)
-        gpio.setup(self.settings.get("echo_pin"), gpio.IN)
+        # Use board numbering which corresponds to the pin numbers on the
+        # P1 header of the board.
+        self.gpio.setmode(self.gpio.BOARD)
+
+        # Configure the input and output pins.
+        self.gpio.setup(self.settings.get("echo_pin"), self.gpio.IN)
+        self.gpio.setup(self.settings.get("trigger_pin"), self.gpio.OUT)
         
-        # Set trigger to false
-        gpio.output(self.settings.get("trigger_pin"), False)
+        # Set trigger to false.
+        self.gpio.output(self.settings.get("trigger_pin"), False)
         time.sleep(self.settings.get("interval_delay"))
 
     def get_distance(self):
-        # Trigger the sensor to start measuring
-        gpio.output(self.settings.get("trigger_pin"), True)
+        # Trigger the sensor to start measuring.
+        self.gpio.output(self.settings.get("trigger_pin"), True)
         time.sleep(self.settings.get("trigger_delay"))
-        gpio.output(self.settings.get("trigger_pin"), False)
+        self.gpio.output(self.settings.get("trigger_pin"), False)
 
-        # Set the start time only when the sensor
-        # is starting to send a signal
+        # Set the start time when the sensor is starting to send a signal.
         start = time.time()
-        while gpio.input(self.settings.get("echo_pin")) == 0:
+        while self.gpio.input(self.settings.get("echo_pin")) == 0:
             start = time.time()
 
-        # Move the end time when the signal has
-        # not been returned yet.
-        while gpio.input(self.settings.get("echo_pin")) == 1:
+        # Move the end time when the signal has not been returned yet.
+        end = time.time()
+        while self.gpio.input(self.settings.get("echo_pin")) == 1:
             end = time.time()
 
-        # Calculate the distance and divide by two
-        # because the signal travels the distance
-        # twice (back and forth).
-        total = end - start
-        distance = (total * self.settings.get("speed_of_sound")) / 2
-        return distance / 100
+        return self._convert_elapsed_time_to_distance(end - start)
+
+    def _convert_elapsed_time_to_distance(self, elapsed_time):
+        # Calculate the distance in centimeters. We divide by two since the
+        # signal travels the distance twice (back and forth).
+        distance_meters = (elapsed_time * self.settings.get("speed_of_sound")) / 2
+        return distance_meters / 100

--- a/tests/distance_sensor_physical.py
+++ b/tests/distance_sensor_physical.py
@@ -1,0 +1,62 @@
+import unittest
+from mock import patch, call, MagicMock
+from ..settings import Settings
+
+class TestDistanceSensorPhysical(unittest.TestCase):
+    def setUp(self):
+        # We need to mock the RPi.GPIO module as it is only available
+        # on Raspberry Pi devices and these tests run on a PC.
+        self.rpi_gpio_mock = MagicMock()
+        modules = {
+            'RPi': self.rpi_gpio_mock,
+            'RPi.GPIO': self.rpi_gpio_mock.GPIO
+        }
+
+        self.patcher = patch.dict('sys.modules', modules)
+        self.patcher.start()
+        from ..distance.Distance_Sensor_Physical import Distance_Sensor_Physical
+        self.settings = Settings("settings.json", "distance_sensor_physical")
+        self.distance_sensor = Distance_Sensor_Physical()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_initialization(self):
+        # Warnings must be disabled.
+        self.distance_sensor.gpio.setwarnings.assert_called_once_with(False)
+
+        # Board numbering has to be used.
+        self.distance_sensor.gpio.setmode.assert_called_once_with(
+            self.distance_sensor.gpio.BOARD)
+
+        # The input and output pins have to be set.
+        self.distance_sensor.gpio.setup.assert_has_calls([
+            call(self.settings.get("echo_pin"), self.distance_sensor.gpio.IN),
+            call(self.settings.get("trigger_pin"), self.distance_sensor.gpio.OUT)
+        ])
+
+        # The trigger signal must be set to false.
+        self.distance_sensor.gpio.output.assert_called_once_with(
+            self.settings.get("trigger_pin"), False)
+
+    def test_elapsed_time_triggers(self):
+        self.distance_sensor.get_distance()
+
+        # The starting trigger has to be created.
+        self.distance_sensor.gpio.output.assert_has_calls([
+            call(self.settings.get("trigger_pin"), True),
+            call(self.settings.get("trigger_pin"), False)
+        ])
+
+        # The echo pin must be checked at least once.
+        self.distance_sensor.gpio.input.assert_called_with(
+            self.settings.get("echo_pin"))
+
+    def test_elapsed_time_to_distance_conversion(self):
+        elapsed_time = 5.153064012527466
+        distance_meters = (elapsed_time * self.settings.get("speed_of_sound")) / 2
+        
+        correct = distance_meters / 100
+        calculated = self.distance_sensor._convert_elapsed_time_to_distance(elapsed_time)
+
+        self.assertEqual(calculated, correct)


### PR DESCRIPTION
Adjust the implementation to make comments more consistent and to factor
the time to distance conversion to a separate method. The latter change
allows us to test this more easily and makes the code more readable.

I have confirmed that the distance sensor still works the same on a
Raspberry Pi.
