### PR TITLE
Settings: Support parent component inheritance

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -37,15 +37,15 @@
     },
     "xbee_tdma_scheduler": {
         "name": "XBee TDMA scheduler",
+        "parent": "xbee_sensor_simulator",
         "settings": {
-            "number_of_sensors": 8,
             "sweep_delay": 16
         }
     },
     "xbee_viewer": {
         "name": "XBee viewer",
+        "parent": "xbee_sensor_simulator",
         "settings": {
-            "number_of_sensors": 8,
             "size": 10,
             "circle_radius": 3
         }

--- a/settings/Settings.py
+++ b/settings/Settings.py
@@ -25,13 +25,24 @@ class Settings(object):
         self.component_name = component_name
 
         settings = self.__class__.get_settings(file_name)
-        if not self.component_name in settings:
+        if self.component_name not in settings:
             raise KeyError("Component '{}' not found.".format(self.component_name))
 
         self.settings = settings[self.component_name]["settings"]
 
+        if "parent" in settings[self.component_name]:
+            self.parent = Settings(file_name, settings[self.component_name]["parent"])
+        else:
+            self.parent = None
+
     def get(self, key):
         if key not in self.settings:
+            if self.parent is not None:
+                try:
+                    return self.parent.get(key)
+                except KeyError:
+                    pass
+
             raise KeyError("Setting '{}' for component '{}' not found.".format(key, self.component_name))
 
         return self.settings[key]

--- a/tests/settings.json
+++ b/tests/settings.json
@@ -5,5 +5,12 @@
             "bar": 2,
             "baz": true
         }
+    },
+    "child": {
+        "name": "Child component",
+        "parent": "foo",
+        "settings": {
+            "baz": false
+        }
     }
 }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,3 +22,11 @@ class TestSettings(unittest.TestCase):
         settings = Settings("tests/settings.json", "foo")
         with self.assertRaises(KeyError):
             settings.get("qux")
+
+    def test_parent(self):
+        settings = Settings("tests/settings.json", "child")
+        self.assertEqual(settings.get("bar"), 2)
+        self.assertEqual(settings.get("baz"), False)
+        # Test: Exception should still mention child component
+        with self.assertRaisesRegexp(KeyError, "'child'"):
+            settings.get("qux")


### PR DESCRIPTION
The XBee components contained a duplicate setting for number_of_sensors.
It seems tedious and error-prone to change all instances of them when
it's mostly only related to the main component right now, the XBee
simulator. Make it possible to transparently get a setting from
a registered parent component to avoid this issue.

Later on the components might even become more hierarchical with base
components for simulated and physical instances of sensors, etc. This
will be helpful in that case, as well.

Added tests to demonstrate that it works.
