### PR TITLE
Arguments parse

### DIFF
--- a/settings/Arguments.py
+++ b/settings/Arguments.py
@@ -59,7 +59,7 @@ class Arguments(object):
             elif value is not None:
                 kw["type"] = type(value)
 
-            group.add_argument("--{}".format(key), **kw)
+            group.add_argument("--{}".format(key.replace('_','-')), **kw)
 
     def _fill_settings(self, settings):
         """

--- a/settings/Arguments.py
+++ b/settings/Arguments.py
@@ -76,8 +76,9 @@ class Arguments(object):
 
         This should be used after all Settings components have been registered,
         so that help for all settings is available.
-        This method will end the program in case a --help argument is given.
+        This method will end the program in case a --help argument is given,
+        or in case nonexistent arguments are given.
         """
 
         self.parser.add_argument('-h', '--help', action='help', help="Show this help message and exit")
-        self.parser.parse_known_args(self.argv)
+        self.parser.parse_args(self.argv)

--- a/settings/Arguments.py
+++ b/settings/Arguments.py
@@ -53,7 +53,7 @@ class Arguments(object):
                 "default": value
             }
             if isinstance(value, list):
-                kw["nargs"] = "?"
+                kw["nargs"] = "*"
                 if len(value) > 0:
                     kw["type"] = type(value[0])
             elif value is not None:

--- a/tests/arguments.py
+++ b/tests/arguments.py
@@ -15,12 +15,13 @@ class TestArguments(unittest.TestCase):
         self.assertEqual(settings.get("bar"), 2)
 
     def test_settings(self):
-        arguments = Arguments("tests/settings.json", ['--bar', '5'])
+        arguments = Arguments("tests/settings.json", ['--bar', '5', '--long-name', 'my_text'])
         settings = arguments.get_settings("foo")
         # We get the same object every time
         self.assertEqual(id(settings), id(arguments.get_settings("foo")))
         # Command line arguments override values in JSON.
         self.assertEqual(settings.get("bar"), 5)
+        self.assertEqual(settings.get("long_name"), "my_text")
 
     def test_check_help(self):
         arguments = Arguments("tests/settings.json", ['--help'])

--- a/tests/arguments.py
+++ b/tests/arguments.py
@@ -15,13 +15,15 @@ class TestArguments(unittest.TestCase):
         self.assertEqual(settings.get("bar"), 2)
 
     def test_settings(self):
-        arguments = Arguments("tests/settings.json", ['--bar', '5', '--long-name', 'my_text'])
+        arguments = Arguments("tests/settings.json", ['--bar', '5', '--long-name', 'my_text', '--items', '4', '5', '--other'])
         settings = arguments.get_settings("foo")
         # We get the same object every time
         self.assertEqual(id(settings), id(arguments.get_settings("foo")))
         # Command line arguments override values in JSON.
         self.assertEqual(settings.get("bar"), 5)
         self.assertEqual(settings.get("long_name"), "my_text")
+        self.assertEqual(settings.get("items"), [4,5])
+        self.assertEqual(arguments.argv, ['--other'])
 
     def test_check_help(self):
         arguments = Arguments("tests/settings.json", ['--help'])

--- a/tests/arguments.py
+++ b/tests/arguments.py
@@ -36,3 +36,18 @@ class TestArguments(unittest.TestCase):
                     arguments.check_help()
 
         self.assertRegexpMatches(output.getvalue(), "--help")
+
+    def test_nonexistent_settings(self):
+        arguments = Arguments("tests/settings.json", ['--qux', '42'])
+
+        # Buffer help output so it doesn't mess up the test output and we can 
+        # actually test whether it prints help.
+        output = StringIO()
+        with patch('sys.stdout', output):
+            with patch('sys.stderr', output):
+                # Test whether the argument parser calls sys.exit on help.
+                # This can be caught as an exception.
+                with self.assertRaises(SystemExit):
+                    arguments.check_help()
+
+        self.assertRegexpMatches(output.getvalue(), "unrecognized arguments")

--- a/tests/settings.json
+++ b/tests/settings.json
@@ -3,7 +3,8 @@
         "name": "Foo component",
         "settings": {
             "bar": 2,
-            "baz": true
+            "baz": true,
+            "long_name": "some_text"
         }
     },
     "child": {

--- a/tests/settings.json
+++ b/tests/settings.json
@@ -4,7 +4,8 @@
         "settings": {
             "bar": 2,
             "baz": true,
-            "long_name": "some_text"
+            "long_name": "some_text",
+            "items": [1,2,3]
         }
     },
     "child": {

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -28,7 +28,8 @@ class TestSettings(unittest.TestCase):
         expected = {
             "bar": 2,
             "baz": True,
-            "long_name": "some_text"
+            "long_name": "some_text",
+            "items": [1,2,3]
         }
         for key, value in settings.get_all():
             self.assertEqual(value, expected[key])

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -27,7 +27,8 @@ class TestSettings(unittest.TestCase):
         settings = Settings("tests/settings.json", "foo")
         expected = {
             "bar": 2,
-            "baz": True
+            "baz": True,
+            "long_name": "some_text"
         }
         for key, value in settings.get_all():
             self.assertEqual(value, expected[key])


### PR DESCRIPTION
- Handles unrecognized arguments with error/help usage.
- Changes underscores to dashes in argument option.
- Handles list arguments correctly.
