### PR TITLE
Arguments: Handle boolean settings

### DIFF
--- a/settings/Arguments.py
+++ b/settings/Arguments.py
@@ -52,14 +52,19 @@ class Arguments(object):
                 "dest": key,
                 "default": value
             }
+            opt = key.replace('_', '-')
             if isinstance(value, list):
                 kw["nargs"] = "*"
                 if len(value) > 0:
                     kw["type"] = type(value[0])
+            elif isinstance(value, bool):
+                kw["action"] = "store_false"
+                group.add_argument("--no-{}".format(opt), **kw)
+                kw["action"] = "store_true"
             elif value is not None:
                 kw["type"] = type(value)
 
-            group.add_argument("--{}".format(key.replace('_','-')), **kw)
+            group.add_argument("--{}".format(opt), **kw)
 
     def _fill_settings(self, settings):
         """

--- a/tests/arguments.py
+++ b/tests/arguments.py
@@ -15,12 +15,13 @@ class TestArguments(unittest.TestCase):
         self.assertEqual(settings.get("bar"), 2)
 
     def test_settings(self):
-        arguments = Arguments("tests/settings.json", ['--bar', '5', '--long-name', 'my_text', '--items', '4', '5', '--other'])
+        arguments = Arguments("tests/settings.json", ['--bar', '5', '--no-baz', '--long-name', 'my_text', '--items', '4', '5', '--other'])
         settings = arguments.get_settings("foo")
         # We get the same object every time
         self.assertEqual(id(settings), id(arguments.get_settings("foo")))
         # Command line arguments override values in JSON.
         self.assertEqual(settings.get("bar"), 5)
+        self.assertEqual(settings.get("baz"), False)
         self.assertEqual(settings.get("long_name"), "my_text")
         self.assertEqual(settings.get("items"), [4,5])
         self.assertEqual(arguments.argv, ['--other'])


### PR DESCRIPTION
If the type of a setting is bool, then we should not rely on the default
behavior of the argument parse to handle it. This is because all
nonempty strings are True, which makes it hard to disable an option.
Instead, we register another argument for a setting x, known as --no-x,
to disable that setting, while just --x enables it.

Add tests to check that the setting is disabled when we pass the --no
version in the arguments.
