### PR TITLE
Implement autostart for Raspberry Pi devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ code. Open a terminal and run the following commands.
 Running the tools
 =================
 
-Now that we have a copy of the software, we can run the tools.
+Now that we have a copy of the software, we can run the tools. Use `sudo` if
+your user is not part of the `dialout` or `uucp` group.
 
 XBee configurator
 -----------------
 
 The XBee configurator is used to quickly prepare all XBee chips in the
-network. Start the configurator with `sudo python2 xbee_configurator.py` to
+network. Start the configurator with `python2 xbee_configurator.py` to
 get started. You might need to adjust the settings for the `xbee_configurator`
 component in `settings.json`, for example to set the right port if the
 default port is not correct. After starting the tool, the instructions for
@@ -70,7 +71,7 @@ XBee sensor (physical)
 
 The physical XBee sensor code controls one XBee chip connected to the
 device via USB. Such a device can either be a computer or a Raspberry
-Pi. Start `screen` and run `sudo python2 xbee_sensor_physical.py` to
+Pi. Start `screen` and run `python2 xbee_sensor_physical.py` to
 activate the XBee chip mounted onto an XBee USB dongle. Each sensor
 constantly receives packets (asynchronously), but sends packets according
 to a fixed TDMA schedule as defined by the settings in `settings.json`.
@@ -92,7 +93,7 @@ Distance sensor (physical)
 
 We assume that you have setup a Raspberry Pi with Arch Linux ARM and
 that you have connected the HC-SR04 sensor. This tool must run on the
-Raspberry Pi. Start the tool with `sudo python2 distance_sensor_physical.py`
+Raspberry Pi. Start the tool with `python2 distance_sensor_physical.py`
 to receive continuous measurements from the distance sensor. Change the pin
 numbers for the trigger and echo pins in `settings.json` if you have used
 different pin numbers when connecting the HC-SR04 sensor to the Raspberry Pi.

--- a/docs/Raspberry_Pi.tex
+++ b/docs/Raspberry_Pi.tex
@@ -104,7 +104,7 @@ over.
           {\tt 10.42.0.10} and the second Raspberry Pi has IP address {\tt 
           10.42.0.11}, and so on.
     \item Unmount the mounts using {\tt umount boot root}. Finally, run {\tt 
-          rm -rf ../\emph{pi\_dir}} to remove the temporary directory.
+          rm -rf~../\emph{pi\_dir}} to remove the temporary directory.
     \item Insert the micro SD card into the Raspberry Pi device. Connect an 
           ethernet cable from the Raspberry Pi to a laptop and then power the 
           Raspberry Pi using a micro USB charger (in that order, as the 
@@ -121,7 +121,7 @@ over.
           password ``alarm''.
     \item Run {\tt su} to become the root superuser. Use the password ``root''.
     \item Edit {\tt /etc/ssh/sshd\_config} and set {\tt PermitRootLogin} to the 
-          value {\tt yes} to allow root login from SSH.
+          value {\tt yes} to allow root login from SSH\@.
     \item Run {\tt systemctl disable dhcpcd@eth0.service} and {\tt systemctl 
           enable network.service}.
     \item Edit {\tt /boot/cmdline.txt} to remove the recently added IP part. 
@@ -157,6 +157,9 @@ over.
     \item Run {\tt pacman -S screen} to use {\tt screen} for running Python
           scripts.
     \item Update the Raspberry Pi frequently using {\tt pacman -Syu}.
+    \item Give the {\tt alarm} user access to USB using
+          {\tt usermod -aG uucp alarm}. After that, reboot the device using
+          {\tt reboot}.
 \end{itemize}
 
 \section{Distance sensor configuration steps}
@@ -177,10 +180,29 @@ over.
     \item Run {\tt pip2 install rpi.gpio} (still as root).
     \item Run {\tt su alarm} and place the file {\tt raspberry-pi/vimrc} in
           {\tt $\sim$/.vimrc}.
-    \item Copy the file {\tt distance\_sensor.py} to the device: \\\\
-          {\tt scp distance\_sensor.py alarm@10.42.0.*:$\sim$/distance\_sensor.py}.
-    \item Run the distance sensor script with {\tt sudo python2 distance\_sensor.py}
+    \item Run the distance sensor script with {\tt python2 distance\_sensor\_physical.py}
           and distance measurements should be displayed continuously.
+\end{itemize}
+
+\section{Autostart configuration steps}
+After booting the Raspberry Pi we immediately want to run the physical XBee
+sensor code instead of starting the script manually using an ethernet cable
+every time. To maintain control over the process we wish to run the process
+in a detached screen. To achieve all this, the following actions have to be
+performed:
+
+\begin{itemize}
+    \item Make sure that the repository is cloned in
+          {\tt /home/alarm/drone-tomography}. If not, edit \\
+          {\tt raspberry-pi/drone-tomography.service} to set the correct path.
+    \item Become root: {\tt su}.
+    \item Place the file {\tt raspberry-pi/drone-tomography.service} in
+          {\tt /etc/systemd/system}.
+    \item Run {\tt systemctl enable drone-tomography.service}.
+    \item Reboot the device: {\tt reboot}. After rebooting, the physical
+          XBee sensor should be running. Verify this by checking if the LEDs on
+          the XBee sensor are blinking and if running {\tt screen -r sensor}
+          opens the detached screen.
 \end{itemize}
 
 \section{References}

--- a/docs/raspberry-pi/drone-tomography.service
+++ b/docs/raspberry-pi/drone-tomography.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Drone tomography
+
+[Service]
+Type=forking
+User=alarm
+ExecStart=/usr/bin/screen -dmS sensor /home/alarm/drone-tomography/raspberry-pi-start.sh
+ExecStop=/usr/bin/screen -S sensor -X quit
+
+[Install]
+WantedBy=multi-user.target

--- a/raspberry-pi-start.sh
+++ b/raspberry-pi-start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd /home/alarm/drone-tomography
+python2 xbee_sensor_physical.py


### PR DESCRIPTION
This allows us to automatically start the physical XBee sensor code in a detached screen after booting the device using a self-written service. This has been tested on the actual Raspberry Pi devices that we have.
