### PR TITLE
Location check

### DIFF
--- a/environment/Environment_Simulator.py
+++ b/environment/Environment_Simulator.py
@@ -60,6 +60,6 @@ class Environment_Simulator(Environment):
         for obj in self.objects:
             if isinstance(obj, list):
                 for face in obj:
-                    cp, factor, loc_point = self.geometry.get_plane_intersection(face, location, new_location)
+                    factor, loc_point = self.geometry.get_plane_intersection(face, location, new_location)
                     if 0 <= factor <= 1:
                         raise RuntimeError("Flew through an object")

--- a/environment/Environment_Simulator.py
+++ b/environment/Environment_Simulator.py
@@ -18,6 +18,9 @@ class Environment_Simulator(Environment):
         if isinstance(self.vehicle, MockVehicle):
             self.vehicle.home_location = self.get_location(*translation)
             self.geometry.set_home_location(self.vehicle.home_location)
+            if scenefile is not None:
+                self.vehicle.set_location_callback(self.check_location)
+
         if scenefile is not None:
             loader = VRMLLoader(self, scenefile, translation)
             self.objects = loader.get_objects()
@@ -52,3 +55,9 @@ class Environment_Simulator(Environment):
 
     def get_objects(self):
         return self.objects
+
+    def check_location(self, location, new_location):
+        for obj in self.objects:
+            if isinstance(obj, list):
+                for face in obj:
+                    print(self.geometry.get_plane_distance(face, location, new_location, verbose=True))

--- a/environment/Environment_Simulator.py
+++ b/environment/Environment_Simulator.py
@@ -60,4 +60,6 @@ class Environment_Simulator(Environment):
         for obj in self.objects:
             if isinstance(obj, list):
                 for face in obj:
-                    print(self.geometry.get_plane_distance(face, location, new_location, verbose=True))
+                    cp, factor, loc_point = self.geometry.get_plane_intersection(face, location, new_location)
+                    if 0 <= factor <= 1:
+                        raise RuntimeError("Flew through an object")

--- a/environment/Environment_Simulator.py
+++ b/environment/Environment_Simulator.py
@@ -18,7 +18,7 @@ class Environment_Simulator(Environment):
         if isinstance(self.vehicle, MockVehicle):
             self.vehicle.home_location = self.get_location(*translation)
             self.geometry.set_home_location(self.vehicle.home_location)
-            if scenefile is not None:
+            if scenefile is not None and self.settings.get("location_check"):
                 self.vehicle.set_location_callback(self.check_location)
 
         if scenefile is not None:

--- a/geometry/Geometry.py
+++ b/geometry/Geometry.py
@@ -1,5 +1,6 @@
 import sys
 import math
+import itertools
 import numpy as np
 from droneapi.lib import Location
 
@@ -190,6 +191,27 @@ class Geometry(object):
 
         return zip(points, list(points[1:]) + [points[0]])
 
+    def point_inside_polygon(self, location, points, alt=True, altitude_margin=0):
+        """
+        Detect objectively whether a `location` is inside an object polygon with points `points`. If `alt` is True, then the points are considered to be upper points of a three-dimensional object extending up to it.
+        """
+        # Simplification: if the point is above the mean altitude of all the 
+        # points, then do not consider it to be inside the polygon. We could 
+        # also perform interesting calculations here, but we won't have that 
+        # many objects of differing altitude anyway.
+        if alt:
+            avg_alt = float(sum([point.alt for point in points]))/len(points)
+            if avg_alt < location.alt - altitude_margin:
+                return False
+
+        edges = self.get_point_edges(points)
+        inside = False
+        for e in edges:
+            if self.ray_intersects_segment(location, e[0], e[1]):
+                inside = not inside
+
+        return inside
+
     def get_plane_vector(self, points):
         """
         Calculate the plane equation from the given `points` that determine a face on the plane.
@@ -230,6 +252,75 @@ class Geometry(object):
         u = u * factor
         loc_point = self.get_location_meters(location, *u)
         return factor, loc_point
+
+    def get_projected_location(self, p, ignore_index):
+        if ignore_index == 0:
+            return Location(p.lon, p.alt, 0)
+        elif ignore_index == 1:
+            return Location(p.lat, p.alt, 0)
+        else:
+            # No need to ignore altitude here since it's ignored by default
+            return p
+
+    def get_plane_distance(self, face, location1, location2, verbose=False):
+        if len(face) < 3:
+            if verbose:
+                print("Face incomplete")
+
+            # Face incomplete
+            return (sys.float_info.max, None)
+
+        cp, d = self.get_plane_vector(face)
+
+        # 3D intersection point
+        # Based on http://stackoverflow.com/a/18543221
+
+        # Equation of the line
+        u = np.array(self.diff_location_meters(location1, location2))
+        # Dot product between the line and the plane vector
+        nu_dot = np.dot(cp, u)
+        if not self.check_dot(nu_dot):
+            if verbose:
+                print("Dot product not good enough, no intersection: dot={}, u={}.".format(nu_dot, u))
+
+            # Dot product not good enough, usually caused by line and plane not 
+            # actually intersecting (line parallel to plane)
+            return (sys.float_info.max, None)
+
+        # Calculate the intersection point
+        factor, loc_point = self.get_intersection(face, cp, location1, u, nu_dot)
+
+        if factor < 0:
+            if verbose:
+                print("Factor too small: {}".format(factor))
+
+            # The factor is too small, which means that the intersection point 
+            # is on the line extending in the other direction, which we need to 
+            # ignore as well.
+            return (sys.float_info.max, None)
+
+        # Point inside 3D polygon check
+        # http://geomalgorithms.com/a03-_inclusion.html#3D-Polygons
+        # Ignore the "least relevant coordinate" by moving the relevant 
+        # coordinates into lat and lon, since those are used by the 2D point 
+        # inside polygon algorithm, and this creates the largest projection of 
+        # the plane.
+        ignore_index = np.argmax(np.absolute(cp))
+
+        ignores = itertools.repeat(ignore_index, len(face))
+        projected_face = map(self.get_projected_location, face, ignores)
+
+        projected_loc = self.get_projected_location(loc_point, ignore_index)
+        if self.point_inside_polygon(projected_loc, projected_face, alt=False):
+            dist = self.get_distance_meters(location1, loc_point)
+            return (dist, loc_point)
+
+        if verbose:
+            print("Point not actually inside polygon")
+
+        # The intersection point is not actually inside the polygon, but on the 
+        # plane extending from it. Thus there is no intersection.
+        return (sys.float_info.max, None)
 
 class Geometry_Spherical(Geometry):
     # Radius of "spherical" earth

--- a/geometry/Geometry.py
+++ b/geometry/Geometry.py
@@ -262,13 +262,13 @@ class Geometry(object):
             # No need to ignore altitude here since it's ignored by default
             return p
 
-    def get_plane_distance(self, face, location1, location2, verbose=False):
+    def get_plane_intersection(self, face, location1, location2, verbose=False):
         if len(face) < 3:
             if verbose:
                 print("Face incomplete")
 
             # Face incomplete
-            return (sys.float_info.max, None)
+            return (None, None, None)
 
         cp, d = self.get_plane_vector(face)
 
@@ -285,12 +285,17 @@ class Geometry(object):
 
             # Dot product not good enough, usually caused by line and plane not 
             # actually intersecting (line parallel to plane)
-            return (sys.float_info.max, None)
+            return (None, None, None)
 
         # Calculate the intersection point
         factor, loc_point = self.get_intersection(face, cp, location1, u, nu_dot)
+        return (cp, factor, loc_point)
 
-        if factor < 0:
+    def get_plane_distance(self, face, location1, location2, verbose=False):
+        cp, factor, loc_point = self.get_plane_intersection(face, location1, location2, verbose)
+        if factor is None:
+            return (sys.float_info.max, None)
+        elif factor <= 0:
             if verbose:
                 print("Factor too small: {}".format(factor))
 

--- a/settings.json
+++ b/settings.json
@@ -48,7 +48,8 @@
             "distance_sensors": [0.0],
             "xbee_type": "",
             "scenefile": null,
-            "translation": [0.0,0.0,0.0]
+            "translation": [0.0,0.0,0.0],
+            "location_check": false
         }
     },
     "environment_viewer": {

--- a/trajectory/MockVehicle.py
+++ b/trajectory/MockVehicle.py
@@ -342,6 +342,9 @@ class MockVehicle(object):
     def set_location_callback(self, location_callback):
         self._location_callback = location_callback
 
+    def unset_location_callback(self):
+        self._location_callback = None
+
     @property
     def attitude(self):
         self._update_location()

--- a/trajectory/MockVehicle.py
+++ b/trajectory/MockVehicle.py
@@ -322,13 +322,7 @@ class MockVehicle(object):
             self._location_callback = False
             try:
                 location_callback(self._location, value)
-            except Exception, e:
-                # Handle exceptions within the callback gracefully:
-                # Ensure that we do not get more exceptions from recursions or 
-                # other problems by unsetting the callback.
-                self._location_callback = None
-                raise e
-            else:
+            finally:
                 self._location_callback = location_callback
 
         self._location = value
@@ -338,6 +332,9 @@ class MockVehicle(object):
         new_location = self._geometry.get_location_meters(self._location, north, east, alt)
 
         self.location = new_location
+
+    def get_location_callback(self):
+        return self._location_callback
 
     def set_location_callback(self, location_callback):
         self._location_callback = location_callback

--- a/trajectory/MockVehicle.py
+++ b/trajectory/MockVehicle.py
@@ -320,8 +320,16 @@ class MockVehicle(object):
         if self._location_callback is not None:
             location_callback = self._location_callback
             self._location_callback = False
-            location_callback(self._location, value)
-            self._location_callback = location_callback
+            try:
+                location_callback(self._location, value)
+            except Exception, e:
+                # Handle exceptions within the callback gracefully:
+                # Ensure that we do not get more exceptions from recursions or 
+                # other problems by unsetting the callback.
+                self._location_callback = None
+                raise e
+            else:
+                self._location_callback = location_callback
 
         self._location = value
         self._update_time = time.time()

--- a/trajectory/Viewer.py
+++ b/trajectory/Viewer.py
@@ -172,6 +172,15 @@ class Viewer(object):
         # Movement (translation change)
         self.strafe = Vector(0.0, 0.0, 0.0)
 
+    def get_update_location(self, dt):
+        strafe_look = dt * self.strafe.z * self.look
+        strafe_up = dt * self.strafe.y * self.up
+        strafe_right = dt * self.strafe.x * self.right
+
+        move = strafe_look + strafe_up + strafe_right
+
+        return self.environment.get_location(move.z, move.x, move.y)
+
     def update(self, dt):
         """
         Update the current location and rotation of the camera.
@@ -180,13 +189,7 @@ class Viewer(object):
         The given `dt` indicates the time in seconds that has passed since the last call to `update`. It can also be `0.0` to skip movement and rotation changes, or `1.0` to do exactly one step of them.
         """
 
-        strafe_look = dt * self.strafe.z * self.look
-        strafe_up = dt * self.strafe.y * self.up
-        strafe_right = dt * self.strafe.x * self.right
-
-        move = strafe_look + strafe_up + strafe_right
-
-        location = self.environment.get_location(move.z, move.x, move.y)
+        location = self.get_update_location(dt)
         self.pos.z, self.pos.x, self.pos.y = self.geometry.diff_location_meters(self.initial_location, location)
 
         # Now perform any rotation changes
@@ -195,7 +198,6 @@ class Viewer(object):
         self.rotation.z = (self.rotation.z + dt * self.orient.z) % 360
 
         self._update_camera()
-        return location
 
     def _rotate_2D(self, angle, M):
         """
@@ -315,7 +317,6 @@ class Viewer_Interactive(Viewer):
         self.vehicle = self.environment.get_vehicle()
         if isinstance(self.vehicle, MockVehicle):
             self.is_mock = True
-            self.vehicle.unset_location_callback()
         else:
             self.is_mock = False
 
@@ -342,10 +343,16 @@ class Viewer_Interactive(Viewer):
         glPolygonMode(GL_FRONT_AND_BACK, GL_LINE)
 
     def update(self, dt):
-        location = super(Viewer_Interactive, self).update(dt)
+        location = self.get_update_location(dt)
         if self.is_mock:
-            self.vehicle.location = location
+            try:
+                self.vehicle.location = location
+            except RuntimeError:
+                return
 
+        super(Viewer_Interactive, self).update(dt)
+
+        if self.is_mock:
             pitch = math.asin(-self.look.y)
             yaw = math.atan2(self.look.x, self.look.z)
             self.vehicle.attitude = MockAttitude(pitch, yaw, 0.0)
@@ -398,6 +405,13 @@ class Viewer_Interactive(Viewer):
             if self.current_face > len(self.objects[self.current_object]):
                 self.current_face = -1
             self._update_tracking()
+        elif symbol == key.F: # toggle flying through objects
+            if self.vehicle.get_location_callback():
+                self.vehicle.unset_location_callback()
+                print("Enabled flying through objects")
+            else:
+                self.vehicle.set_location_callback(self.environment.check_location)
+                print("Disabled flying through objects")
         elif symbol == key.Q: # quit
             pyglet.app.exit()
             return

--- a/trajectory/Viewer.py
+++ b/trajectory/Viewer.py
@@ -315,6 +315,7 @@ class Viewer_Interactive(Viewer):
         self.vehicle = self.environment.get_vehicle()
         if isinstance(self.vehicle, MockVehicle):
             self.is_mock = True
+            self.vehicle.unset_location_callback()
         else:
             self.is_mock = False
 


### PR DESCRIPTION
Add a setting (disabled by default) that allows the vehicle simulator to check whether a callback detects a problem with a location update. This is used to check whether the vehicle moved through an object, which should not happen due to the distance sensor checks, but is helpful to determine whether a mission has problems.

Also moves a method out of the distance sensor and into Geometry as separate small methods that can be reused for point/line in plane/polygon intersection.
