### PR TITLE
Weight matrix: Return snapped points, remove required check

### DIFF
--- a/reconstruction/Weight_Matrix.py
+++ b/reconstruction/Weight_Matrix.py
@@ -30,8 +30,11 @@ class Weight_Matrix(object):
 
     def update(self, source, destination):
         """
-        Update the weight matrix. Each update adds a new row to the matrix.
-        This method returns whether or not the update was successful.
+        Update the weight matrix with a measurement between a `source` and
+        `destination` sensor, both given as a tuple of coordinates.
+        Each successful update adds a new row to the matrix.
+        This method returns a list of coordinate tuples for the two sensors
+        in case the update was successful. Otherwise, `None` is returned.
 
         Refer to the following papers for the principles or code
         that this method is based on:
@@ -45,7 +48,7 @@ class Weight_Matrix(object):
         snapped_points = self._snapper.execute(source, destination)
         if snapped_points is None:
             # If the points cannot be snapped, ignore the measurement.
-            return False
+            return None
 
         source, destination = snapped_points
 
@@ -84,7 +87,7 @@ class Weight_Matrix(object):
         row = (1.0 / np.sqrt(length)) * weight
         self._matrix = np.vstack([self._matrix, row])
 
-        return True
+        return snapped_points
 
     def check(self):
         """
@@ -96,11 +99,8 @@ class Weight_Matrix(object):
 
     def output(self):
         """
-        Output the weight matrix only if it is complete.
+        Output the weight matrix.
         """
-
-        if not self.check():
-            raise ValueError("The weight matrix contains columns with only zeros.")
 
         return self._matrix
 

--- a/tests/reconstruction_weight_matrix.py
+++ b/tests/reconstruction_weight_matrix.py
@@ -12,21 +12,23 @@ class TestReconstructionWeightMatrix(unittest.TestCase):
 
     def test_update(self):
         # Lines that cannot be snapped to the boundary should return False.
-        self.assertFalse(self.weight_matrix.update([0, 5], [5, 5]))
+        self.assertEqual(self.weight_matrix.update((0, 5), (5, 5)), None)
 
         # The weight matrix should not be correct yet.
         self.assertFalse(self.weight_matrix.check())
 
         for i in range(0, 4):
-            self.assertTrue(self.weight_matrix.update([0, i], [4, i]))
-            self.assertTrue(self.weight_matrix.update([i, 0], [i, 4]))
+            points = [(0, i), (4, i)]
+            self.assertEqual(self.weight_matrix.update(*points), points)
+            points = [(i, 0), (i, 4)]
+            self.assertEqual(self.weight_matrix.update(*points), points)
 
         self.assertTrue(self.weight_matrix.check())
 
     def test_reset(self):
         for i in range(0, 4):
-            self.weight_matrix.update([0, i], [4, i])
-            self.weight_matrix.update([i, 0], [i, 4])
+            self.weight_matrix.update((0, i), (4, i))
+            self.weight_matrix.update((i, 0), (i, 4))
 
         self.assertTrue(self.weight_matrix.check())
 


### PR DESCRIPTION
This is necessary for the reconstruction planning to work correctly.
Instead of only returning whether the update was successful, also give
the snapped points.

Additionally, the output method of the weight matrix no longer requires
the matrix to pass the checks, which means that callers need to do so
themselves.

Updated documentation with more details about input/output conditions,
and update tests to match.

Closes #43.
