### PR TITLE
XBee: Compatibility with pySerial 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
 install:
-  - pip install "pyserial==2.7"
+  - pip install pyserial
   - pip install xbee
   - pip install pymavlink
   - pip install mavproxy

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ different installation procedures.
   Ensure that you have the correct version of `pip` with `pip --version` or use
   `pip2` instead.
 
-  Use `pip install --user <package>` to install each of the following packages,
-  sorted by purpose:
+  Use `pip install --user <package>` to install or upgrade each of the 
+  following packages, sorted by purpose:
   * General packages:
     * matplotlib
     * NumPy
     * scipy
   * Physical sensor/communication interfaces:
-    * pyserial (you may need to use `pip install --user "pyserial==2.7"`)
+    * pyserial
     * RPi.GPIO
     * xbee
     * python-lirc

--- a/zigbee/XBee_Configurator.py
+++ b/zigbee/XBee_Configurator.py
@@ -19,7 +19,8 @@ class XBee_Configurator(object):
             raise ValueError("'settings' must be an instance of Settings or Arguments")
 
         self._serial_connection = serial.Serial(self.settings.get("port"),
-                                                self.settings.get("baud_rate"))
+                                                self.settings.get("baud_rate"),
+                                                rtscts=True, dsrdtr=True)
         self._sensor = ZigBee(self._serial_connection)
         time.sleep(self.settings.get("startup_delay"))
 

--- a/zigbee/XBee_Sensor_Physical.py
+++ b/zigbee/XBee_Sensor_Physical.py
@@ -56,7 +56,8 @@ class XBee_Sensor_Physical(XBee_Sensor):
         # Lazily initialize the serial connection and ZigBee object.
         if self._serial_connection is None and self._sensor is None:
             self._serial_connection = serial.Serial(self.settings.get("port"),
-                                                    self.settings.get("baud_rate"))
+                                                    self.settings.get("baud_rate"),
+                                                    rtscts=True, dsrdtr=True)
             self._sensor = ZigBee(self._serial_connection, callback=self._receive)
             time.sleep(self.settings.get("startup_delay"))
             self._join()


### PR DESCRIPTION
Make the XBee component compatible with the newest version of pySerial.
Previously, version 3.0 would give an IOError for some internal control
flag setting. The fix appears to be to enable the RTS and DTR control
lines at initialization. This makes the tests pass with Serial 3.0
installed. Also tested with the physical XBees.

Updated the README and travis dependencies to match.

Closes #51.
