### PR TITLE
Tests settings

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,5 @@
 #/bin/bash
 python2 -m unittest discover -s tests -p "*.py" -t ..
+RESULT=$?
 rm -f logs/*.log
+exit $RESULT

--- a/tests/arguments.py
+++ b/tests/arguments.py
@@ -2,11 +2,9 @@ import unittest
 from mock import patch
 from StringIO import StringIO
 from ..settings import Arguments, Settings
+from settings import SettingsTestCase
 
-class TestArguments(unittest.TestCase):
-    def tearDown(self):
-        Settings.settings_files = {}
-
+class TestArguments(SettingsTestCase):
     def test_default_settings(self):
         arguments = Arguments("tests/invalid.json", ["tests/settings.json"])
         # Command line input for settings file is initialized immediately

--- a/tests/distance_sensor_physical.py
+++ b/tests/distance_sensor_physical.py
@@ -1,8 +1,9 @@
 import unittest
 from mock import patch, call, MagicMock
 from ..settings import Arguments
+from settings import SettingsTestCase
 
-class TestDistanceSensorPhysical(unittest.TestCase):
+class TestDistanceSensorPhysical(SettingsTestCase):
     def setUp(self):
         # We need to mock the RPi.GPIO module as it is only available
         # on Raspberry Pi devices and these tests run on a PC.
@@ -22,6 +23,7 @@ class TestDistanceSensorPhysical(unittest.TestCase):
         self.distance_sensor = environment.get_distance_sensors()[0]
 
     def tearDown(self):
+        super(TestDistanceSensorPhysical, self).tearDown()
         self.patcher.stop()
 
     def test_initialization(self):

--- a/tests/geometry.py
+++ b/tests/geometry.py
@@ -6,6 +6,7 @@ from ..geometry.Geometry import Geometry, Geometry_Spherical
 
 class LocationTestCase(unittest.TestCase):
     def setUp(self):
+        super(LocationTestCase, self).setUp()
         self.addTypeEqualityFunc(LocationLocal, self.assertLocationLocalEqual)
         self.addTypeEqualityFunc(LocationGlobal, self.assertLocationGlobalEqual)
         self.addTypeEqualityFunc(LocationGlobalRelative, self.assertLocationGlobalEqual)

--- a/tests/location_line_follower_raspberry_pi.py
+++ b/tests/location_line_follower_raspberry_pi.py
@@ -2,8 +2,9 @@ import unittest
 from mock import patch, call, MagicMock
 from ..core.Thread_Manager import Thread_Manager
 from ..settings import Arguments
+from settings import SettingsTestCase
 
-class TestLocationLineFollowerRaspberryPi(unittest.TestCase):
+class TestLocationLineFollowerRaspberryPi(SettingsTestCase):
     def setUp(self):
         # We need to mock the RPi.GPIO module as it is only available
         # on Raspberry Pi devices and these tests run on a PC.
@@ -33,6 +34,7 @@ class TestLocationLineFollowerRaspberryPi(unittest.TestCase):
         )
 
     def tearDown(self):
+        super(TestLocationLineFollowerRaspberryPi, self).tearDown()
         self.patcher.stop()
 
     def test_initialization(self):

--- a/tests/memory_map.py
+++ b/tests/memory_map.py
@@ -2,12 +2,13 @@ import unittest
 import math
 import numpy as np
 import sys
-from geometry import LocationTestCase
 from ..environment import Environment
 from ..trajectory.Memory_Map import Memory_Map
 from ..settings import Arguments
+from geometry import LocationTestCase
+from settings import SettingsTestCase
 
-class TestMemoryMap(LocationTestCase):
+class TestMemoryMap(LocationTestCase, SettingsTestCase):
     def setUp(self):
         super(TestMemoryMap, self).setUp()
         self.arguments = Arguments("settings.json",

--- a/tests/mission_cycle.py
+++ b/tests/mission_cycle.py
@@ -5,13 +5,14 @@ import itertools
 import time
 from mock import patch
 from dronekit import LocationLocal
-from geometry import LocationTestCase
 from ..environment.Environment import Environment
 from ..trajectory.Mission import Mission_Cycle
 from ..vehicle.Robot_Vehicle import Robot_State
 from ..settings import Arguments
+from geometry import LocationTestCase
+from settings import SettingsTestCase
 
-class TestMissionCycle(LocationTestCase):
+class TestMissionCycle(LocationTestCase, SettingsTestCase):
     def setUp(self):
         super(TestMissionCycle, self).setUp()
 
@@ -29,6 +30,10 @@ class TestMissionCycle(LocationTestCase):
 
         settings = self.arguments.get_settings("mission")
         self.mission = Mission_Cycle(self.environment, settings)
+
+    def tearDown(self):
+        super(TestMissionCycle, self).tearDown()
+        self.vehicle.deactivate()
 
     def test_setup(self):
         with patch('sys.stdout'):

--- a/tests/reconstruction_weight_matrix.py
+++ b/tests/reconstruction_weight_matrix.py
@@ -1,8 +1,9 @@
 import unittest
 from ..reconstruction.Weight_Matrix import Weight_Matrix
 from ..settings.Arguments import Arguments
+from settings import SettingsTestCase
 
-class TestReconstructionWeightMatrix(unittest.TestCase):
+class TestReconstructionWeightMatrix(SettingsTestCase):
     def setUp(self):
         origin = [0, 0]
         size = [4, 4]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,7 +12,6 @@ class SettingsTestCase(unittest.TestCase):
 
     def tearDown(self):
         super(SettingsTestCase, self).tearDown()
-        print("Tearing down settings for '{}'".format(self.__class__.__name__))
         Settings.settings_files = {}
 
 class TestSettings(SettingsTestCase):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,10 +1,21 @@
 import unittest
 from ..settings import Settings
 
-class TestSettings(unittest.TestCase):
+class SettingsTestCase(unittest.TestCase):
+    """
+    A test case that makes use of Arguments or Settings.
+    These tests should always clean up the static state of Settings so that
+    any changes made in the Settings objects do not bleed through into other
+    tests, which could cause intermittent passes or fails depending on the
+    test running order.
+    """
+
     def tearDown(self):
+        super(SettingsTestCase, self).tearDown()
+        print("Tearing down settings for '{}'".format(self.__class__.__name__))
         Settings.settings_files = {}
 
+class TestSettings(SettingsTestCase):
     def test_missing_file(self):
         with self.assertRaises(IOError):
             settings = Settings("tests/invalid.json", "foo")

--- a/tests/vrmlloader.py
+++ b/tests/vrmlloader.py
@@ -1,10 +1,11 @@
 import unittest
-from geometry import LocationTestCase
 from ..environment import Environment
 from ..environment.VRMLLoader import VRMLLoader
 from ..settings import Arguments
+from geometry import LocationTestCase
+from settings import SettingsTestCase
 
-class TestVRMLLoader(LocationTestCase):
+class TestVRMLLoader(LocationTestCase, SettingsTestCase):
     def setUp(self):
         super(TestVRMLLoader, self).setUp()
         self.arguments = Arguments("settings.json", [])

--- a/tests/xbee_configurator.py
+++ b/tests/xbee_configurator.py
@@ -3,11 +3,12 @@ import pty
 import os
 import serial
 from mock import patch
-from ..settings import Arguments
-from ..zigbee.XBee_Configurator import XBee_Configurator
 from xbee import ZigBee
+from ..zigbee.XBee_Configurator import XBee_Configurator
+from ..settings import Arguments
+from settings import SettingsTestCase
 
-class TestXBeeConfigurator(unittest.TestCase):
+class TestXBeeConfigurator(SettingsTestCase):
     def setUp(self):
         # Create a virtual serial port.
         master, slave = pty.openpty()

--- a/tests/xbee_sensor_physical.py
+++ b/tests/xbee_sensor_physical.py
@@ -8,11 +8,12 @@ import time
 from xbee import ZigBee
 from mock import patch
 from ..core.Thread_Manager import Thread_Manager
-from ..settings import Arguments
 from ..zigbee.XBee_Packet import XBee_Packet
 from ..zigbee.XBee_Sensor_Physical import XBee_Sensor_Physical
+from ..settings import Arguments
+from settings import SettingsTestCase
 
-class TestXBeeSensorPhysical(unittest.TestCase):
+class TestXBeeSensorPhysical(SettingsTestCase):
     def location_callback(self):
         """
         Get the current GPS location (latitude and longitude pair).

--- a/tests/xbee_sensor_simulator.py
+++ b/tests/xbee_sensor_simulator.py
@@ -6,11 +6,12 @@ import copy
 import Queue
 from mock import patch, MagicMock
 from ..core.Thread_Manager import Thread_Manager
-from ..settings import Arguments
 from ..zigbee.XBee_Packet import XBee_Packet
 from ..zigbee.XBee_Sensor_Simulator import XBee_Sensor_Simulator
+from ..settings import Arguments
+from settings import SettingsTestCase
 
-class TestXBeeSensorSimulator(unittest.TestCase):
+class TestXBeeSensorSimulator(SettingsTestCase):
     def location_callback(self):
         """
         Get the current GPS location (latitude and longitude pair).

--- a/tests/xbee_tdma_scheduler.py
+++ b/tests/xbee_tdma_scheduler.py
@@ -1,10 +1,11 @@
 import time
 import unittest
-from ..settings import Settings
 from ..zigbee.XBee_Packet import XBee_Packet
 from ..zigbee.XBee_TDMA_Scheduler import XBee_TDMA_Scheduler
+from ..settings import Settings
+from settings import SettingsTestCase
 
-class TestXBeeTDMAScheduler(unittest.TestCase):
+class TestXBeeTDMAScheduler(SettingsTestCase):
     def setUp(self):
         self.id = 2
         self.settings = Settings("settings.json", "xbee_tdma_scheduler")


### PR DESCRIPTION
- Fix the test runner to return status code for Travis.
- Reset the settings cache in test cases that make use of Arguments or Settings. This ensures that settings changes do not bleed into other tests.

This unbreaks Travis misreporting tests, and is a blocker for the `vehicle-infrared` branch to ensure that settings changes only apply for the test they are meant for.
