### PR TITLE
Integrate infrared sensor into mission/vehicle environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 install:
   - pip install pyserial
   - pip install xbee
+  - pip install pylirc2
   - pip install pymavlink
   - pip install mavproxy
   - pip install dronekit

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
 install:
   - pip install pyserial
   - pip install xbee
-  - pip install pylirc2
   - pip install pymavlink
   - pip install mavproxy
   - pip install dronekit

--- a/control/Infrared_Sensor.py
+++ b/control/Infrared_Sensor.py
@@ -131,7 +131,7 @@ class Infrared_Sensor(Threadable):
                 callback = self._release_listeners[self._previous_button]
                 callback()
 
-                self.previous_button = None
+            self._previous_button = None
 
     def deactivate(self):
         """

--- a/control/remotes/Sony_RM-SRB5.lircrc
+++ b/control/remotes/Sony_RM-SRB5.lircrc
@@ -9,3 +9,31 @@ begin
     prog = mobile-radio-tomography
     config = stop
 end
+
+begin
+    button = vol+
+    prog = mobile-radio-tomography
+    config = up
+    repeat = 1
+end
+
+begin
+    button = vol-
+    prog = mobile-radio-tomography
+    config = down
+    repeat = 1
+end
+
+begin
+    button = previous
+    prog = mobile-radio-tomography
+    config = left
+    repeat = 1
+end
+
+begin
+    button = next
+    prog = mobile-radio-tomography
+    config = right
+    repeat = 1
+end

--- a/docs/Raspberry_Pi.tex
+++ b/docs/Raspberry_Pi.tex
@@ -127,6 +127,14 @@ over.
           10.42.0.10 to 10.42.0.11. If after this change you cannot SSH into 
           the device, run {\tt nmap -sP 10.42.0.0/24} on your computer to 
           determine which IP address was assigned to the device.
+    \item Create a directory {\tt mkdir /etc/systemd/system/dhcpcd@.service.d} 
+          and go to that directory with {\tt cd 
+          /etc/systemd/system/dhcpcd@.service.d}. Then edit {\tt timeout.conf} 
+          to add the following lines:
+
+          {\tt [Service]} \\
+          {\tt ExecStart=} \\
+          {\tt ExecStart=/usr/bin/dhcpcd -w -q -t 5 \%I}
     \item Edit {\tt /boot/cmdline.txt} to remove the recently added IP part.
           After that, reboot the Raspberry Pi device.
     \item On your laptop, edit the old link-local connection. Change the type 

--- a/docs/raspberry-pi/mobile-radio-tomography.service
+++ b/docs/raspberry-pi/mobile-radio-tomography.service
@@ -1,11 +1,16 @@
 [Unit]
 Description=Mobile radio tomography
+Requires=lircd.service
+After=lircd.service
 
 [Service]
 Type=forking
 User=root
 ExecStart=/usr/bin/screen -dmS sensor /home/alarm/mobile-radio-tomography/raspberry-pi-start.sh
 ExecStop=/usr/bin/screen -S sensor -X quit
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
+

--- a/environment/Environment.py
+++ b/environment/Environment.py
@@ -81,6 +81,11 @@ class Environment(object):
         self.packet_callbacks = {}
         self._setup_xbee_sensor()
 
+        if self.settings.get("infrared_sensor"):
+            self._infrared_sensor = Infrared_Sensor(arguments, thread_manager)
+        else:
+            self._infrared_sensor = None
+
         self.vehicle.add_attribute_listener('home_location', self.on_home_location)
         self.vehicle.add_attribute_listener('servos', self.on_servos)
 
@@ -132,6 +137,9 @@ class Environment(object):
 
     def get_xbee_sensor(self):
         return self._xbee_sensor
+
+    def get_infrared_sensor(self):
+        return self._infrared_sensor
 
     def add_packet_action(self, action, callback):
         self.packet_callbacks[action] = callback

--- a/environment/Environment.py
+++ b/environment/Environment.py
@@ -1,5 +1,6 @@
 import math
 from ..core.Thread_Manager import Thread_Manager
+from ..control.Infrared_Sensor import Infrared_Sensor
 from ..geometry import Geometry
 from ..trajectory.Servo import Servo
 from ..vehicle.Vehicle import Vehicle

--- a/environment/Environment.py
+++ b/environment/Environment.py
@@ -1,6 +1,5 @@
 import math
 from ..core.Thread_Manager import Thread_Manager
-from ..control.Infrared_Sensor import Infrared_Sensor
 from ..geometry import Geometry
 from ..trajectory.Servo import Servo
 from ..vehicle.Vehicle import Vehicle
@@ -83,6 +82,7 @@ class Environment(object):
         self._setup_xbee_sensor()
 
         if self.settings.get("infrared_sensor"):
+            from ..control.Infrared_Sensor import Infrared_Sensor
             self._infrared_sensor = Infrared_Sensor(arguments, thread_manager)
         else:
             self._infrared_sensor = None

--- a/mission_basic.py
+++ b/mission_basic.py
@@ -91,8 +91,9 @@ class Setup(object):
 
         # Return to lauch at the end of the mission or when we can safely 
         # return before a potential problem.
-        self.monitor.stop()
-        self.mission.return_to_launch()
+        if self.activated:
+            self.monitor.stop()
+            self.mission.return_to_launch()
 
     def disable(self):
         if self.activated:

--- a/mission_basic.py
+++ b/mission_basic.py
@@ -31,7 +31,7 @@ class Setup(object):
         mission_class = self.settings.get("mission_class")
         self.mission = Mission.__dict__[mission_class](self.environment, self.settings)
 
-        self.monitor = Monitor(mission, environment)
+        self.monitor = Monitor(self.mission, self.environment)
 
         self.arguments.check_help()
 
@@ -46,7 +46,7 @@ class Setup(object):
         self.mission.arm_and_takeoff()
         self.mission.display()
 
-        infrared_sensor = environment.get_infrared_sensor()
+        infrared_sensor = self.environment.get_infrared_sensor()
         if infrared_sensor is not None:
             infrared_sensor.register("start", self.enable)
             infrared_sensor.register("stop", self.disable)

--- a/mission_basic.py
+++ b/mission_basic.py
@@ -74,7 +74,7 @@ class Setup(object):
                 viewer.start()
             else:
                 ok = True
-                while ok:
+                while ok and self.activated:
                     ok = self.monitor.step()
                     if ok:
                         self.monitor.sleep()
@@ -95,8 +95,11 @@ class Setup(object):
         self.mission.return_to_launch()
 
     def disable(self):
-        self.monitor.stop()
-        self.environment.thread_manager.destroy()
+        if self.activated:
+            self.activated = False
+            print("Stopped mission")
+            self.monitor.stop()
+            self.environment.thread_manager.destroy()
 
 def main(argv):
     arguments = Arguments("settings.json", argv)

--- a/raspberry-pi-start.sh
+++ b/raspberry-pi-start.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd /home/alarm/mobile-radio-tomography
-python2 xbee_sensor_physical.py --synchronize
+python2 mission_basic.py --vehicle-class Robot_Vehicle_Arduino --mission-class Mission_Infrared --serial-device /dev/ttyUSB0 --geometry-class Geometry --servo-pins --distance-sensors --no-plot --no-viewer --speed 0.2 --step-delay 0.25 > logs/output.log 2> logs/error.log

--- a/settings.json
+++ b/settings.json
@@ -91,6 +91,7 @@
                 }
             ],
             "xbee_type": "",
+            "infrared_sensor": true,
             "scenefile": null,
             "translation": [0.0,0.0,0.0],
             "location_check": false

--- a/settings.json
+++ b/settings.json
@@ -22,7 +22,7 @@
         "settings": {
             "remote": "Sony_RM-SRB5",
             "program": "mobile-radio-tomography",
-            "buttons": ["start", "stop"],
+            "buttons": ["start", "stop", "up", "down", "left", "right"],
             "wait_delay": 0.05
         }
     },

--- a/tests/control_infrared_sensor.py
+++ b/tests/control_infrared_sensor.py
@@ -108,6 +108,7 @@ class TestControlInfraredSensor(unittest.TestCase):
         self.assertFalse(mock_release_callback.called)
 
         self.infrared_sensor._handle_lirc_code(None)
+        self.infrared_sensor._handle_lirc_code(None)
         self.assertEqual(mock_callback.call_count, 1)
         self.assertEqual(mock_release_callback.call_count, 1)
         # Start button was not pressed.

--- a/tests/control_infrared_sensor.py
+++ b/tests/control_infrared_sensor.py
@@ -1,0 +1,114 @@
+import unittest
+from mock import patch, call, MagicMock
+from ..core.Thread_Manager import Thread_Manager
+from ..settings import Arguments
+
+class TestControlInfraredSensor(unittest.TestCase):
+    def setUp(self):
+        # We need to mock the pylirc module as we do not want to use actual 
+        # LIRC communication. We assume the pylirc module works as expected.
+        self.pylirc_mock = MagicMock()
+        modules = {
+            'pylirc': self.pylirc_mock
+        }
+
+        self.patcher = patch.dict('sys.modules', modules)
+        self.patcher.start()
+
+        from ..control.Infrared_Sensor import Infrared_Sensor
+        # Skip configuration checks since we emulate the behavior of LIRC. We 
+        # test the configuration checks in test_initialize.
+        self.old_configure = Infrared_Sensor._configure
+        Infrared_Sensor._configure = MagicMock()
+
+        thread_manager = Thread_Manager()
+
+        self.arguments = Arguments("settings.json", [])
+        self.settings = self.arguments.get_settings("infrared_sensor")
+        self.infrared_sensor = Infrared_Sensor(self.settings, thread_manager)
+        self.mock_callback = MagicMock()
+
+    def tearDown(self):
+        # Reset mock configure method so that we do not lose the original 
+        # method during multiple tests.
+        from ..control.Infrared_Sensor import Infrared_Sensor
+        Infrared_Sensor._configure = self.old_configure
+
+        # Stop all active patchers. Useful for when a test fails midway so that 
+        # it does not affect other tests.
+        patch.stopall()
+
+    def test_initialize(self):
+        # Test initialization of infrared sensor with a local variable rather 
+        # than the one already created at setUp.
+        thread_manager = Thread_Manager()
+
+        # Test whether we check that we have /etc/lirc installed
+        methods = {
+            'isdir.return_value': False
+        }
+        patcher = patch('os.path', **methods)
+        patcher.start()
+        from ..control.Infrared_Sensor import Infrared_Sensor
+        Infrared_Sensor._configure = self.old_configure
+        with self.assertRaises(OSError) as cm:
+            infrared_sensor = Infrared_Sensor(self.settings, thread_manager)
+
+        self.assertIn("not installed", cm.exception.message)
+        patcher.stop()
+
+        # Test whether we check that the remote exists
+        methods = {
+            'isdir.return_value': True,
+            'isfile.return_value': False
+        }
+        patcher = patch('os.path', **methods)
+        patcher.start()
+        with self.assertRaises(OSError) as cm:
+            infrared_sensor = Infrared_Sensor(self.settings, thread_manager)
+
+        self.assertIn("does not exist", cm.exception.message)
+        patcher.stop()
+
+    def test_register(self):
+        # We must have an existing button.
+        with self.assertRaises(KeyError):
+            self.infrared_sensor.register("!nonexistent malformed button!", self.mock_callback)
+
+        # We must have a (normal) callback.
+        with self.assertRaises(ValueError):
+            self.infrared_sensor.register("start", None)
+
+        # We must have callable functions for all given callbacks.
+        with self.assertRaises(ValueError):
+            self.infrared_sensor.register("stop", self.mock_callback, "not a function")
+
+    def test_callbacks(self):
+        # Test normal event callback.
+        self.infrared_sensor.register("start", self.mock_callback)
+
+        self.infrared_sensor._handle_lirc_code(None)
+        self.assertFalse(self.mock_callback.called)
+        self.infrared_sensor._handle_lirc_code(['start'])
+        self.assertEqual(self.mock_callback.call_count, 1)
+
+        # Test additional release callback.
+        self.mock_callback.reset_mock()
+        mock_callback = MagicMock()
+        mock_release_callback = MagicMock()
+
+        self.infrared_sensor.register("stop", mock_callback, mock_release_callback)
+
+        self.infrared_sensor._handle_lirc_code(None)
+        self.assertFalse(mock_callback.called)
+        self.assertFalse(mock_release_callback.called)
+
+        self.infrared_sensor._handle_lirc_code(['stop'])
+        self.assertEqual(mock_callback.call_count, 1)
+        self.assertFalse(mock_release_callback.called)
+
+        self.infrared_sensor._handle_lirc_code(None)
+        self.assertEqual(mock_callback.call_count, 1)
+        self.assertEqual(mock_release_callback.call_count, 1)
+        # Start button was not pressed.
+        self.assertFalse(self.mock_callback.called)

--- a/tests/distance_sensor_physical.py
+++ b/tests/distance_sensor_physical.py
@@ -16,7 +16,9 @@ class TestDistanceSensorPhysical(unittest.TestCase):
         self.patcher.start()
         from ..environment import Environment
         from ..distance.Distance_Sensor_Physical import Distance_Sensor_Physical
-        arguments = Arguments("settings.json", ["--sensors", "0"])
+        arguments = Arguments("settings.json", [
+            "--sensors", "0", "--no-infrared-sensor"
+        ])
         self.settings = arguments.get_settings("distance_sensor_physical")
         environment = Environment.setup(arguments, simulated=False)
         self.distance_sensor = environment.get_distance_sensors()[0]

--- a/tests/memory_map.py
+++ b/tests/memory_map.py
@@ -10,9 +10,9 @@ from ..settings import Arguments
 class TestMemoryMap(LocationTestCase):
     def setUp(self):
         super(TestMemoryMap, self).setUp()
-        self.arguments = Arguments("settings.json",
-            ["--vehicle-class", "Mock_Vehicle"]
-        )
+        self.arguments = Arguments("settings.json", [
+            "--vehicle-class", "Mock_Vehicle", "--no-infrared-sensor"
+        ])
         self.environment = Environment.setup(self.arguments, geometry_class="Geometry", simulated=True)
         self.coord_delta = sys.float_info.epsilon * 10
     

--- a/tests/mission_cycle.py
+++ b/tests/mission_cycle.py
@@ -22,7 +22,8 @@ class TestMissionCycle(LocationTestCase):
 
         self.arguments = Arguments("settings.json", [
             "--vehicle-class", "Robot_Vehicle_Arduino", "--space-size", "3",
-            "--serial-device", self.port, "--serial-flow-control"
+            "--serial-device", self.port, "--serial-flow-control",
+            "--no-infrared-sensor"
         ])
         self.environment = Environment.setup(self.arguments, geometry_class="Geometry", simulated=True)
         self.vehicle = self.environment.get_vehicle()

--- a/tests/vrmlloader.py
+++ b/tests/vrmlloader.py
@@ -7,7 +7,9 @@ from ..settings import Arguments
 class TestVRMLLoader(LocationTestCase):
     def setUp(self):
         super(TestVRMLLoader, self).setUp()
-        self.arguments = Arguments("settings.json", ["--no-infrared-sensor"])
+        self.arguments = Arguments("settings.json", [
+            "--vehicle-class", "Mock_Vehicle", "--no-infrared-sensor"
+        ])
         self.environment = Environment.setup(self.arguments, simulated=True)
 
     def test_load(self):

--- a/tests/vrmlloader.py
+++ b/tests/vrmlloader.py
@@ -7,7 +7,7 @@ from ..settings import Arguments
 class TestVRMLLoader(LocationTestCase):
     def setUp(self):
         super(TestVRMLLoader, self).setUp()
-        self.arguments = Arguments("settings.json", [])
+        self.arguments = Arguments("settings.json", ["--no-infrared-sensor"])
         self.environment = Environment.setup(self.arguments, simulated=True)
 
     def test_load(self):

--- a/trajectory/Mission.py
+++ b/trajectory/Mission.py
@@ -712,7 +712,7 @@ class Mission_Infrared(Mission_Guided):
             self.vehicle.set_speeds(*self._motor_speeds)
 
         self._motor_speeds = (0, 0, True, True)
-        self._motor_turn = -1
+        self._motor_turn = 0
 
     def _up(self):
         self._motor_speeds = (self.speed, self.speed, True, True)

--- a/trajectory/Mission.py
+++ b/trajectory/Mission.py
@@ -686,19 +686,21 @@ class Mission_Pathfind(Mission_Browse, Mission_Square):
 
 class Mission_Infrared(Mission_Guided):
     def setup(self):
-        super(Mission_Guided, self).setup()
+        super(Mission_Infrared, self).setup()
 
         if not isinstance(self.vehicle, Robot_Vehicle):
             raise ValueError("Mission_Infrared only works with robot vehicles")
 
-        infrared_sensor = self.environment.get_infrared_sensor()
-        if infrared_sensor is None:
+        self.infrared_sensor = self.environment.get_infrared_sensor()
+        if self.infrared_sensor is None:
             raise ValueError("Mission_Infrared only works with infrared sensor")
 
-        infrared_sensor.register("up", self._up)
-        infrared_sensor.register("down", self._down)
-        infrared_sensor.register("left", self._left)
-        infrared_sensor.register("right", self._right)
+    def start(self):
+        super(Mission_Infrared, self).start()
+        self.infrared_sensor.register("up", self._up)
+        self.infrared_sensor.register("down", self._down)
+        self.infrared_sensor.register("left", self._left)
+        self.infrared_sensor.register("right", self._right)
 
     def step(self):
         self.vehicle.set_speeds(0,0)

--- a/trajectory/Mission.py
+++ b/trajectory/Mission.py
@@ -706,10 +706,10 @@ class Mission_Infrared(Mission_Guided):
         self.infrared_sensor.register("right", self._right)
 
     def step(self):
-        if self._motor_speeds:
-            self.vehicle.set_speeds(*self._motor_speeds)
-        elif self._motor_turn != 0:
+        if self._motor_turn != 0:
             self.vehicle.set_rotate(self._motor_turn)
+        else:
+            self.vehicle.set_speeds(*self._motor_speeds)
 
         self._motor_speeds = (0, 0, True, True)
         self._motor_turn = -1

--- a/trajectory/Mission.py
+++ b/trajectory/Mission.py
@@ -695,36 +695,27 @@ class Mission_Infrared(Mission_Guided):
         if self.infrared_sensor is None:
             raise ValueError("Mission_Infrared only works with infrared sensor")
 
-        self._motor_speeds = (0, 0, True, True)
-        self._motor_turn = 0
-
     def start(self):
         super(Mission_Infrared, self).start()
-        self.infrared_sensor.register("up", self._up)
-        self.infrared_sensor.register("down", self._down)
-        self.infrared_sensor.register("left", self._left)
-        self.infrared_sensor.register("right", self._right)
+        self.infrared_sensor.register("up", self._up, self._release)
+        self.infrared_sensor.register("down", self._down, self._release)
+        self.infrared_sensor.register("left", self._left, self._release)
+        self.infrared_sensor.register("right", self._right, self._release)
 
-    def step(self):
-        if self._motor_turn != 0:
-            self.vehicle.set_rotate(self._motor_turn)
-        else:
-            self.vehicle.set_speeds(*self._motor_speeds)
-
-        self._motor_speeds = (0, 0, True, True)
-        self._motor_turn = 0
+    def _release(self):
+        self.vehicle.set_speeds(0, 0, True, True)
 
     def _up(self):
-        self._motor_speeds = (self.speed, self.speed, True, True)
+        self.vehicle.set_speeds(self.speed, self.speed, True, True)
 
     def _down(self):
-        self._motor_speeds = (self.speed, self.speed, False, False)
+        self.vehicle.set_speeds(self.speed, self.speed, False, False)
 
     def _left(self):
-        self._motor_turn = -1
+        self.vehicle.set_rotate(-1)
 
     def _right(self):
-        self._motor_turn = 1
+        self.vehicle.set_rotate(1)
 
 class Mission_Cycle(Mission_Guided):
     def setup(self):

--- a/trajectory/Mission.py
+++ b/trajectory/Mission.py
@@ -695,6 +695,8 @@ class Mission_Infrared(Mission_Guided):
         if self.infrared_sensor is None:
             raise ValueError("Mission_Infrared only works with infrared sensor")
 
+        self._motor_speeds = (0, 0, True, True)
+
     def start(self):
         super(Mission_Infrared, self).start()
         self.infrared_sensor.register("up", self._up)
@@ -703,19 +705,20 @@ class Mission_Infrared(Mission_Guided):
         self.infrared_sensor.register("right", self._right)
 
     def step(self):
-        self.vehicle.set_speeds(0,0)
+        self.vehicle.set_speeds(*self._motor_speeds)
+        self._motor_speeds = (0, 0, True, True)
 
     def _up(self):
-        self.vehicle.set_speeds(self.speed, self.speed)
+        self._motor_speeds = (self.speed, self.speed, True, True)
 
     def _down(self):
-        self.vehicle.set_speeds(self.speed, self.speed, False, False)
+        self._motor_speeds = (self.speed, self.speed, False, False)
 
     def _left(self):
-        self.vehicle.set_speeds(self.speed, self.speed, False, True)
+        self._motor_speeds = (self.speed, self.speed, False, True)
 
     def _right(self):
-        self.vehicle.set_speeds(self.speed, self.speed, True, False)
+        self._motor_speeds = (self.speed, self.speed, True, False)
 
 class Mission_Cycle(Mission_Guided):
     def setup(self):

--- a/trajectory/Mission.py
+++ b/trajectory/Mission.py
@@ -696,6 +696,7 @@ class Mission_Infrared(Mission_Guided):
             raise ValueError("Mission_Infrared only works with infrared sensor")
 
         self._motor_speeds = (0, 0, True, True)
+        self._motor_turn = 0
 
     def start(self):
         super(Mission_Infrared, self).start()
@@ -705,8 +706,13 @@ class Mission_Infrared(Mission_Guided):
         self.infrared_sensor.register("right", self._right)
 
     def step(self):
-        self.vehicle.set_speeds(*self._motor_speeds)
+        if self._motor_speeds:
+            self.vehicle.set_speeds(*self._motor_speeds)
+        elif self._motor_turn != 0:
+            self.vehicle.set_rotate(self._motor_turn)
+
         self._motor_speeds = (0, 0, True, True)
+        self._motor_turn = -1
 
     def _up(self):
         self._motor_speeds = (self.speed, self.speed, True, True)
@@ -715,10 +721,10 @@ class Mission_Infrared(Mission_Guided):
         self._motor_speeds = (self.speed, self.speed, False, False)
 
     def _left(self):
-        self._motor_speeds = (self.speed, self.speed, False, True)
+        self._motor_turn = -1
 
     def _right(self):
-        self._motor_speeds = (self.speed, self.speed, True, False)
+        self._motor_turn = 1
 
 class Mission_Cycle(Mission_Guided):
     def setup(self):

--- a/trajectory/Mission.py
+++ b/trajectory/Mission.py
@@ -684,6 +684,37 @@ class Mission_Pathfind(Mission_Browse, Mission_Square):
     def cost(self, start, goal):
         return self.geometry.get_distance_meters(start, goal)
 
+class Mission_Infrared(Mission_Guided):
+    def setup(self):
+        super(Mission_Guided, self).setup()
+
+        if not isinstance(self.vehicle, Robot_Vehicle):
+            raise ValueError("Mission_Infrared only works with robot vehicles")
+
+        infrared_sensor = self.environment.get_infrared_sensor()
+        if infrared_sensor is None:
+            raise ValueError("Mission_Infrared only works with infrared sensor")
+
+        infrared_sensor.register("up", self._up)
+        infrared_sensor.register("down", self._down)
+        infrared_sensor.register("left", self._left)
+        infrared_sensor.register("right", self._right)
+
+    def step(self):
+        self.vehicle.set_speeds(0,0)
+
+    def _up(self):
+        self.vehicle.set_speeds(self.speed, self.speed)
+
+    def _down(self):
+        self.vehicle.set_speeds(self.speed, self.speed, False, False)
+
+    def _left(self):
+        self.vehicle.set_speeds(self.speed, self.speed, False, True)
+
+    def _right(self):
+        self.vehicle.set_speeds(self.speed, self.speed, True, False)
+
 class Mission_Cycle(Mission_Guided):
     def setup(self):
         super(Mission_Guided, self).setup()

--- a/vehicle/Robot_Vehicle.py
+++ b/vehicle/Robot_Vehicle.py
@@ -299,6 +299,9 @@ class Robot_Vehicle(Vehicle):
         # Start turning the vehicle at turning speed. If we want to rotate 
         # clockwise, the left motor goes forward and the right motor backward, 
         # while counterclockwise is the other way around.
+        self.set_rotate(rotate_direction)
+
+    def set_rotate(self, rotate_direction):
         self.set_speeds(self._rotate_speed, self._rotate_speed, rotate_direction == 1, rotate_direction == -1)
 
     def _move_waypoint(self):

--- a/vehicle/Robot_Vehicle_Arduino.py
+++ b/vehicle/Robot_Vehicle_Arduino.py
@@ -29,6 +29,7 @@ class Robot_Vehicle_Arduino(Robot_Vehicle):
         self._speed_servos = [Servo(i, self._speeds, self._speed_pwms) for i in range(2)]
 
         self._serial_connection = self._line_follower.get_serial_connection()
+        self._current_speed = (0, 0, True, True)
 
     def setup(self):
         self._serial_connection.reset_output_buffer()
@@ -48,6 +49,14 @@ class Robot_Vehicle_Arduino(Robot_Vehicle):
         super(Robot_Vehicle_Arduino, self).deactivate()
 
     def set_speeds(self, left_speed, right_speed, left_forward=True, right_forward=True):
+        new_speed = (left_speed, right_speed, left_forward, right_forward)
+        if self._current_speed == new_speed:
+            # Avoid sending the same message multiple times after each other, 
+            # since the Arduino will keep at the same speed until a different 
+            # message appears.
+            return
+
+        self._current_speed = new_speed
         output = ""
         for i, speed, forward in [(0, left_speed, left_forward), (1, right_speed, right_forward)]:
             if not forward:


### PR DESCRIPTION
- Handle start/stop presses for delaying the start of the mission and stopping it when we want to.
- `Mission_Infrared` can drive a robot vehicle based on up/down (forward/backward) and left/right (turning) button presses on the remote. Tweaks to reduce delays.
- Add service for starting this mission with specific settings that work well for the vehicle's payload and the specific mission. We can later move some parameters to a production settings file, which could lead to some changes to the `Settings` infrastructure that is better suited for another PR.
- Release event callbacks for the `Infrared_Sensor`.
- Tests for `Infrared_Sensor`. Tests that use the `Environment` but do not mock `pylirc` should specify `--no-infrared-sensor` in their `Arguments` overrides.
