### PR TITLE
XBee node discovery

### DIFF
--- a/control_panel/Control_Panel_Controller.py
+++ b/control_panel/Control_Panel_Controller.py
@@ -4,6 +4,7 @@ import sys
 import traceback
 from PyQt4 import QtGui
 from Control_Panel_View import Control_Panel_View_Name
+from Control_Panel_Devices_View import Control_Panel_Devices_View
 from Control_Panel_Loading_View import Control_Panel_Loading_View
 from Control_Panel_Reconstruction_View import Control_Panel_Reconstruction_View
 from Control_Panel_Waypoints_View import Control_Panel_Waypoints_View
@@ -89,6 +90,7 @@ class Control_Panel_Controller(object):
             self._view_actions[name].setChecked(True)
 
         views = {
+            Control_Panel_View_Name.DEVICES: Control_Panel_Devices_View,
             Control_Panel_View_Name.LOADING: Control_Panel_Loading_View,
             Control_Panel_View_Name.RECONSTRUCTION: Control_Panel_Reconstruction_View,
             Control_Panel_View_Name.WAYPOINTS: Control_Panel_Waypoints_View
@@ -121,6 +123,7 @@ class Control_Panel_Controller(object):
 
         # Views that are visible in the menu and their action labels.
         view_names = OrderedDict([
+            (Control_Panel_View_Name.DEVICES, "Devices"),
             (Control_Panel_View_Name.RECONSTRUCTION, "Reconstruction"),
             (Control_Panel_View_Name.WAYPOINTS, "Waypoints")
         ])

--- a/control_panel/Control_Panel_Devices_View.py
+++ b/control_panel/Control_Panel_Devices_View.py
@@ -36,7 +36,6 @@ class Control_Panel_Devices_View(Control_Panel_View):
             XBee_Device("Vehicle 2", 2, XBee_Device_Category.END_DEVICE)
         ]
         self._refresh_ground_station()
-        self._fill()
 
         # Create the refresh button.
         refresh_button = QtGui.QPushButton("Refresh")
@@ -79,8 +78,6 @@ class Control_Panel_Devices_View(Control_Panel_View):
 
         self._refresh_ground_station()
         self._refresh_vehicles()
-        self._tree_view.clear()
-        self._fill()
 
     def _refresh_ground_station(self):
         """
@@ -93,10 +90,25 @@ class Control_Panel_Devices_View(Control_Panel_View):
         ground_station.address = identity["address"]
         ground_station.joined = identity["joined"]
 
+        self._tree_view.clear()
+        self._fill()
+
     def _refresh_vehicles(self):
         """
         Refresh the status of the vehicles.
         """
 
-        # TODO: Implement node discovery.
-        pass
+        self._controller.xbee.discover(self._refresh_vehicle)
+
+    def _refresh_vehicle(self, packet):
+        """
+        Refresh a single vehicle using information from in
+        node discovery XBee packet.
+        """
+
+        vehicle = self._devices[packet["id"]]
+        vehicle.address = packet["address"]
+        vehicle.joined = True
+
+        self._tree_view.clear()
+        self._fill()

--- a/control_panel/Control_Panel_Devices_View.py
+++ b/control_panel/Control_Panel_Devices_View.py
@@ -6,12 +6,12 @@ class XBee_Device_Category(object):
     END_DEVICE = 2
 
 class XBee_Device(object):
-    def __init__(self, name, id, category, address, joined):
+    def __init__(self, name, id, category):
         self.name = name
         self.id = id
         self.category = category
-        self.address = address
-        self.joined = joined
+        self.address = None
+        self.joined = False
 
 class Control_Panel_Devices_View(Control_Panel_View):
     def show(self):
@@ -31,9 +31,9 @@ class Control_Panel_Devices_View(Control_Panel_View):
 
         # Fill the tree view with the devices.
         self._devices = [
-            XBee_Device("Ground station", 0, XBee_Device_Category.COORDINATOR, "12:34:56:78:9A:BC", True),
-            XBee_Device("Vehicle 1", 1, XBee_Device_Category.END_DEVICE, "DE:F1:23:45:67:89", False),
-            XBee_Device("Vehicle 2", 2, XBee_Device_Category.END_DEVICE, "AB:CD:EF:12:34:56", False)
+            XBee_Device("Ground station", 0, XBee_Device_Category.COORDINATOR),
+            XBee_Device("Vehicle 1", 1, XBee_Device_Category.END_DEVICE),
+            XBee_Device("Vehicle 2", 2, XBee_Device_Category.END_DEVICE)
         ]
         self._fill()
 
@@ -65,7 +65,7 @@ class Control_Panel_Devices_View(Control_Panel_View):
             item = QtGui.QTreeWidgetItem(self._tree_view, [device.name])
             item_id = QtGui.QTreeWidgetItem(item, ["ID", str(device.id)])
             item_category = QtGui.QTreeWidgetItem(item, ["Category", categories[device.category]])
-            item_address = QtGui.QTreeWidgetItem(item, ["Address", device.address])
+            item_address = QtGui.QTreeWidgetItem(item, ["Address", device.address if device.address is not None else "-"])
             item_joined = QtGui.QTreeWidgetItem(item, ["Joined", "Yes" if device.joined else "No"])
 
         # Expand all items in the tree view.

--- a/control_panel/Control_Panel_Devices_View.py
+++ b/control_panel/Control_Panel_Devices_View.py
@@ -10,7 +10,7 @@ class XBee_Device(object):
         self.name = name
         self.id = id
         self.category = category
-        self.address = None
+        self.address = "-"
         self.joined = False
 
 class Control_Panel_Devices_View(Control_Panel_View):
@@ -66,7 +66,7 @@ class Control_Panel_Devices_View(Control_Panel_View):
             item = QtGui.QTreeWidgetItem(self._tree_view, [device.name])
             item_id = QtGui.QTreeWidgetItem(item, ["ID", str(device.id)])
             item_category = QtGui.QTreeWidgetItem(item, ["Category", categories[device.category]])
-            item_address = QtGui.QTreeWidgetItem(item, ["Address", device.address if device.address is not None else "-"])
+            item_address = QtGui.QTreeWidgetItem(item, ["Address", device.address])
             item_joined = QtGui.QTreeWidgetItem(item, ["Joined", "Yes" if device.joined else "No"])
 
         # Expand all items in the tree view.
@@ -78,7 +78,7 @@ class Control_Panel_Devices_View(Control_Panel_View):
         """
 
         self._refresh_ground_station()
-        # TODO: update vehicle status using node discovery
+        self._refresh_vehicles()
         self._tree_view.clear()
         self._fill()
 
@@ -92,3 +92,11 @@ class Control_Panel_Devices_View(Control_Panel_View):
         ground_station = self._devices[0]
         ground_station.address = identity["address"]
         ground_station.joined = identity["joined"]
+
+    def _refresh_vehicles(self):
+        """
+        Refresh the status of the vehicles.
+        """
+
+        # TODO: Implement node discovery.
+        pass

--- a/control_panel/Control_Panel_Devices_View.py
+++ b/control_panel/Control_Panel_Devices_View.py
@@ -35,6 +35,7 @@ class Control_Panel_Devices_View(Control_Panel_View):
             XBee_Device("Vehicle 1", 1, XBee_Device_Category.END_DEVICE),
             XBee_Device("Vehicle 2", 2, XBee_Device_Category.END_DEVICE)
         ]
+        self._refresh_ground_station()
         self._fill()
 
         # Create the refresh button.
@@ -76,7 +77,18 @@ class Control_Panel_Devices_View(Control_Panel_View):
         Refresh the status of the ground station and the vehicles.
         """
 
-        # TODO: update ground station status
+        self._refresh_ground_station()
         # TODO: update vehicle status using node discovery
         self._tree_view.clear()
         self._fill()
+
+    def _refresh_ground_station(self):
+        """
+        Refresh the status of the ground station.
+        """
+
+        identity = self._controller.xbee.get_identity()
+
+        ground_station = self._devices[0]
+        ground_station.address = identity["address"]
+        ground_station.joined = identity["joined"]

--- a/control_panel/Control_Panel_Devices_View.py
+++ b/control_panel/Control_Panel_Devices_View.py
@@ -1,0 +1,58 @@
+from PyQt4 import QtGui
+from Control_Panel_View import Control_Panel_View
+
+class XBee_Device_Type(object):
+    COORDINATOR = 0
+    END_DEVICE = 2
+
+class XBee_Device_Name(object):
+    COORDINATOR = "Coordinator"
+    END_DEVICE = "End device"
+
+class Control_Panel_Devices_View(Control_Panel_View):
+    def show(self):
+        """
+        Show the devices view.
+        """
+
+        self._add_menu_bar()
+
+        # Create the tree view.
+        tree_view = QtGui.QTreeWidget()
+
+        # Create the header for the tree view.
+        header = QtGui.QTreeWidgetItem(["Device", "Property value"])
+        tree_view.setHeaderItem(header)
+        tree_view.header().setResizeMode(0, QtGui.QHeaderView.Stretch);
+
+        # Create the items for the tree view.
+        ground_station = QtGui.QTreeWidgetItem(tree_view, ["Ground station"])
+        ground_station_id = QtGui.QTreeWidgetItem(ground_station, ["ID", "0"])
+        ground_station_type = QtGui.QTreeWidgetItem(ground_station, ["Type", XBee_Device_Name.COORDINATOR])
+        ground_station_address = QtGui.QTreeWidgetItem(ground_station, ["Address", "01:55:A2:A3:55:7E"])
+        ground_station_joined = QtGui.QTreeWidgetItem(ground_station, ["Joined", "Yes"])
+
+        # Expand all items in the tree view.
+        tree_view.expandToDepth(0)
+
+        # Create the refresh button.
+        refresh_button = QtGui.QPushButton("Refresh")
+        refresh_button.clicked.connect(lambda: self._refresh())
+
+        # Create the layout and add the widgets.
+        hbox = QtGui.QHBoxLayout()
+        hbox.addWidget(refresh_button)
+        hbox.addStretch(1)
+
+        vbox = QtGui.QVBoxLayout(self._controller.central_widget)
+        vbox.addLayout(hbox)
+        vbox.addWidget(tree_view)
+
+    def _refresh(self):
+        """
+        Refresh the status of the ground station and the vehicles.
+        """
+
+        # TODO: update ground station status
+        # TODO: update vehicle status using node discovery
+        pass

--- a/control_panel/Control_Panel_Devices_View.py
+++ b/control_panel/Control_Panel_Devices_View.py
@@ -1,13 +1,17 @@
 from PyQt4 import QtGui
 from Control_Panel_View import Control_Panel_View
 
-class XBee_Device_Type(object):
+class XBee_Device_Category(object):
     COORDINATOR = 0
     END_DEVICE = 2
 
-class XBee_Device_Name(object):
-    COORDINATOR = "Coordinator"
-    END_DEVICE = "End device"
+class XBee_Device(object):
+    def __init__(self, name, id, category, address, joined):
+        self.name = name
+        self.id = id
+        self.category = category
+        self.address = address
+        self.joined = joined
 
 class Control_Panel_Devices_View(Control_Panel_View):
     def show(self):
@@ -18,22 +22,20 @@ class Control_Panel_Devices_View(Control_Panel_View):
         self._add_menu_bar()
 
         # Create the tree view.
-        tree_view = QtGui.QTreeWidget()
+        self._tree_view = QtGui.QTreeWidget()
 
         # Create the header for the tree view.
         header = QtGui.QTreeWidgetItem(["Device", "Property value"])
-        tree_view.setHeaderItem(header)
-        tree_view.header().setResizeMode(0, QtGui.QHeaderView.Stretch);
+        self._tree_view.setHeaderItem(header)
+        self._tree_view.header().setResizeMode(0, QtGui.QHeaderView.Stretch);
 
-        # Create the items for the tree view.
-        ground_station = QtGui.QTreeWidgetItem(tree_view, ["Ground station"])
-        ground_station_id = QtGui.QTreeWidgetItem(ground_station, ["ID", "0"])
-        ground_station_type = QtGui.QTreeWidgetItem(ground_station, ["Type", XBee_Device_Name.COORDINATOR])
-        ground_station_address = QtGui.QTreeWidgetItem(ground_station, ["Address", "01:55:A2:A3:55:7E"])
-        ground_station_joined = QtGui.QTreeWidgetItem(ground_station, ["Joined", "Yes"])
-
-        # Expand all items in the tree view.
-        tree_view.expandToDepth(0)
+        # Fill the tree view with the devices.
+        self._devices = [
+            XBee_Device("Ground station", 0, XBee_Device_Category.COORDINATOR, "12:34:56:78:9A:BC", True),
+            XBee_Device("Vehicle 1", 1, XBee_Device_Category.END_DEVICE, "DE:F1:23:45:67:89", False),
+            XBee_Device("Vehicle 2", 2, XBee_Device_Category.END_DEVICE, "AB:CD:EF:12:34:56", False)
+        ]
+        self._fill()
 
         # Create the refresh button.
         refresh_button = QtGui.QPushButton("Refresh")
@@ -46,7 +48,28 @@ class Control_Panel_Devices_View(Control_Panel_View):
 
         vbox = QtGui.QVBoxLayout(self._controller.central_widget)
         vbox.addLayout(hbox)
-        vbox.addWidget(tree_view)
+        vbox.addWidget(self._tree_view)
+
+    def _fill(self):
+        """
+        Fill the tree view with the device information.
+        """
+
+        categories = {
+            XBee_Device_Category.COORDINATOR: "Coordinator",
+            XBee_Device_Category.END_DEVICE: "End device"
+        }
+
+        # Add an entry in the tree view for each device.
+        for device in self._devices:
+            item = QtGui.QTreeWidgetItem(self._tree_view, [device.name])
+            item_id = QtGui.QTreeWidgetItem(item, ["ID", str(device.id)])
+            item_category = QtGui.QTreeWidgetItem(item, ["Category", categories[device.category]])
+            item_address = QtGui.QTreeWidgetItem(item, ["Address", device.address])
+            item_joined = QtGui.QTreeWidgetItem(item, ["Joined", "Yes" if device.joined else "No"])
+
+        # Expand all items in the tree view.
+        self._tree_view.expandToDepth(0)
 
     def _refresh(self):
         """
@@ -55,4 +78,5 @@ class Control_Panel_Devices_View(Control_Panel_View):
 
         # TODO: update ground station status
         # TODO: update vehicle status using node discovery
-        pass
+        self._tree_view.clear()
+        self._fill()

--- a/control_panel/Control_Panel_Loading_View.py
+++ b/control_panel/Control_Panel_Loading_View.py
@@ -53,6 +53,6 @@ class Control_Panel_Loading_View(Control_Panel_View):
                 sys.exit(1)
 
             self._controller.xbee.activate()
-            self._controller.show_view(Control_Panel_View_Name.WAYPOINTS)
+            self._controller.show_view(Control_Panel_View_Name.DEVICES)
         except KeyError:
             QtCore.QTimer.singleShot(self._xbee_insertion_delay, lambda: self._insertion_loop())

--- a/control_panel/Control_Panel_View.py
+++ b/control_panel/Control_Panel_View.py
@@ -1,9 +1,10 @@
 from PyQt4 import QtCore, QtGui
 
 class Control_Panel_View_Name(object):
-    LOADING = 1
-    RECONSTRUCTION = 2
-    WAYPOINTS = 3
+    DEVICES = 1
+    LOADING = 2
+    RECONSTRUCTION = 3
+    WAYPOINTS = 4
 
 class Control_Panel_View(object):
     def __init__(self, controller):

--- a/tests/xbee_sensor_physical.py
+++ b/tests/xbee_sensor_physical.py
@@ -65,6 +65,14 @@ class TestXBeeSensorPhysical(USBManagerTestCase, ThreadableTestCase, SettingsTes
         self.assertIsInstance(self.sensor._queue, Queue.Queue)
         self.assertEqual(self.sensor._queue.qsize(), 0)
 
+    def test_get_identity(self):
+        # The identity of the device must be returned as a dictionary.
+        identity = self.sensor.get_identity()
+        self.assertIsInstance(identity, dict)
+        self.assertEqual(identity["id"], self.sensor_id)
+        self.assertEqual(identity["address"], "-")
+        self.assertEqual(identity["joined"], False)
+
     def test_setup(self):
         # Set all status variables to True to avoid being stuck in
         # the join loops. We cannot test the join process in the unit tests.

--- a/tests/xbee_sensor_simulator.py
+++ b/tests/xbee_sensor_simulator.py
@@ -37,7 +37,7 @@ class TestXBeeSensorSimulator(ThreadableTestCase, SettingsTestCase):
         self.patcher = patch.dict('sys.modules', modules)
         self.patcher.start()
 
-        self.id = 1
+        self.sensor_id = 1
         self.arguments = Arguments("settings.json", [
             "--warnings", "--xbee-id", "1"
         ])
@@ -54,7 +54,7 @@ class TestXBeeSensorSimulator(ThreadableTestCase, SettingsTestCase):
 
     def test_initialization(self):
         # The ID of the sensor must be set.
-        self.assertEqual(self.sensor.id, self.id)
+        self.assertEqual(self.sensor.id, self.sensor_id)
 
         # The next timestamp must be set.
         self.assertNotEqual(self.sensor._next_timestamp, 0)
@@ -70,6 +70,14 @@ class TestXBeeSensorSimulator(ThreadableTestCase, SettingsTestCase):
         # The custom packet queue must be empty.
         self.assertIsInstance(self.sensor._queue, Queue.Queue)
         self.assertEqual(self.sensor._queue.qsize(), 0)
+
+    def test_get_identity(self):
+        # The identity of the device must be returned as a dictionary.
+        identity = self.sensor.get_identity()
+        self.assertIsInstance(identity, dict)
+        self.assertEqual(identity["id"], self.sensor_id)
+        self.assertEqual(identity["address"], "{}:{}".format(self.sensor._ip, self.sensor._port))
+        self.assertEqual(identity["joined"], True)
 
     def test_enqueue(self):
         # Packets that are not XBee_Packet objects should be refused.

--- a/zigbee/XBee_Sensor.py
+++ b/zigbee/XBee_Sensor.py
@@ -45,6 +45,9 @@ class XBee_Sensor(Threadable):
         self._receive_callback = receive_callback
         self._valid_callback = valid_callback
 
+    def get_identity(self):
+        raise NotImplementedError("Subclasses must implement `get_identity()`")
+
     def setup(self):
         raise NotImplementedError("Subclasses must implement `setup()`")
 

--- a/zigbee/XBee_Sensor.py
+++ b/zigbee/XBee_Sensor.py
@@ -57,6 +57,9 @@ class XBee_Sensor(Threadable):
     def enqueue(self, packet, to=None):
         raise NotImplementedError("Subclasses must implement `enqueue(packet, to=None)`")
 
+    def discover(self, callback):
+        raise NotImplementedError("Subclasses must implement `discover(callback)`")
+
     def _send(self):
         raise NotImplementedError("Subclasses must implement `_send()`")
 

--- a/zigbee/XBee_Sensor_Physical.py
+++ b/zigbee/XBee_Sensor_Physical.py
@@ -49,6 +49,18 @@ class XBee_Sensor_Physical(XBee_Sensor):
         for index, address in enumerate(self._sensors):
             self._sensors[index] = address.decode("string_escape")
 
+    def get_identity(self):
+        """
+        Get the identity (ID, address and join status) of this sensor.
+        """
+
+        identity = {
+            "id": self.id,
+            "address": self._address,
+            "joined": self._joined
+        }
+        return identity
+
     def setup(self):
         """
         Setup the serial connection and identify the sensor.

--- a/zigbee/XBee_Sensor_Physical.py
+++ b/zigbee/XBee_Sensor_Physical.py
@@ -1,10 +1,11 @@
+import copy
 import os
+import Queue
+import random
 import subprocess
+import struct
 import thread
 import time
-import random
-import copy
-import Queue
 from xbee import ZigBee
 from XBee_Packet import XBee_Packet
 from XBee_Sensor import XBee_Sensor
@@ -54,9 +55,12 @@ class XBee_Sensor_Physical(XBee_Sensor):
         Get the identity (ID, address and join status) of this sensor.
         """
 
+        # Pretty print the address.
+        address = "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x" % struct.unpack("BBBBBBBB", self._address)
+
         identity = {
             "id": self.id,
-            "address": self._address,
+            "address": address.upper(),
             "joined": self._joined
         }
         return identity

--- a/zigbee/XBee_Sensor_Physical.py
+++ b/zigbee/XBee_Sensor_Physical.py
@@ -56,7 +56,9 @@ class XBee_Sensor_Physical(XBee_Sensor):
         """
 
         # Pretty print the address.
-        address = "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x" % struct.unpack("BBBBBBBB", self._address)
+        address = "-"
+        if self._address is not None:
+            address = "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x" % struct.unpack("BBBBBBBB", self._address)
 
         identity = {
             "id": self.id,

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -150,7 +150,7 @@ class XBee_Sensor_Simulator(XBee_Sensor):
         # The simulator does not use XBee device discovery because it does not
         # use the actual XBee library that provides this functionality. We
         # simulate the process by calling the callback with the packet manually.
-        for vehicle in [1, 2]:
+        for vehicle in xrange(1, self.settings.get("number_of_sensors") + 1):
             packet = {
                 "id": self.id + vehicle,
                 "address": "{}:{}".format(self._ip, self._port + self.id + vehicle)

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -138,6 +138,16 @@ class XBee_Sensor_Simulator(XBee_Sensor):
                     "to": to_id
                 })
 
+    def discover(self, callback):
+        """
+        Discover other XBee devices in the network.
+
+        This method is only used on the ground station in the control panel
+        to refresh the status of the other XBee devices.
+        """
+
+        pass
+
     def _send(self):
         """
         Send packets to all other sensors in the network.

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -87,6 +87,7 @@ class XBee_Sensor_Simulator(XBee_Sensor):
                 try:
                     data = self._socket.recv(self.settings.get("buffer_size"))
                 except socket.error:
+                    time.sleep(self._loop_delay)
                     continue
 
                 # Unserialize the data (byte-encoded string).

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -146,7 +146,15 @@ class XBee_Sensor_Simulator(XBee_Sensor):
         to refresh the status of the other XBee devices.
         """
 
-        pass
+        # The simulator does not use XBee device discovery because it does not
+        # use the actual XBee library that provides this functionality. We
+        # simulate the process by calling the callback with the packet manually.
+        for vehicle in [1, 2]:
+            packet = {
+                "id": self.id + vehicle,
+                "address": "{}:{}".format(self._ip, self._port + self.id + vehicle)
+            }
+            callback(packet)
 
     def _send(self):
         """

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -35,6 +35,18 @@ class XBee_Sensor_Simulator(XBee_Sensor):
         self._port = self.settings.get("port")
         self._socket = None
 
+    def get_identity(self):
+        """
+        Get the identity (ID, address and join status) of this sensor.
+        """
+
+        identity = {
+            "id": self.id,
+            "address": "{}:{}".format(self._ip, self._port),
+            "joined": True
+        }
+        return identity
+
     def setup(self):
         """
         Setup the socket connection.


### PR DESCRIPTION
This patch implements a devices view in the control panel that allows us to track the status of all XBee devices in the network. We use XBee's built-in node discovery functionality to let the ground station discover other devices in the network. When we found a device in the network, the `ND` packet contains its node identifier and address, which we store in the devices view.

We show the devices view immediately after the loading view because one needs to be sure that the XBees have joined the network before sending any waypoints to them.

@lhelwerd I already did extensive tests with this, but I do not merge this PR immediately in case you would like to look at the code too. Let me know if you have any comments or if you're fine with it, because then I'll update the PR and merge it. It's probably best to look at the overall diff and it should not be too hard to follow, but I did add some more comments in the commit messages.
