### PR TITLE
XBee: refactor custom packet handling

### DIFF
--- a/control_panel/Control_Panel_Loading_View.py
+++ b/control_panel/Control_Panel_Loading_View.py
@@ -46,7 +46,7 @@ class Control_Panel_Loading_View(Control_Panel_View):
             self._controller.app.processEvents()
 
             self._controller.xbee.setup()
-            if self._controller.xbee._id != 0:
+            if self._controller.xbee.id != 0:
                 QtGui.QMessageBox.critical(self._controller.central_widget, "XBee error",
                                            "The inserted XBee device is not a ground station.")
                 self._controller.window.close()

--- a/mission_basic.py
+++ b/mission_basic.py
@@ -62,7 +62,7 @@ class Setup(object):
 
     def start(self):
         print("Starting mission")
-        self.mission.start()
+        self.monitor.start()
 
         # Monitor mission
         try:

--- a/settings.json
+++ b/settings.json
@@ -213,6 +213,7 @@
         "settings": {
             "number_of_sensors": 2,
             "xbee_id": 0,
+            "custom_packet_delay": 0.1,
             "custom_packet_limit": 1,
             "loop_delay": 0.01,
             "startup_delay": 1,
@@ -418,7 +419,6 @@
                 "\\x00\\x13\\xa2\\x00@\\xe6o5",
                 "\\x00\\x13\\xa2\\x00@\\xe6n\\xb9"
             ],
-            "ground_station_delay": 0.1,
             "ntp_delay": 3,
             "response_delay": 0.3,
             "synchronize": false

--- a/settings.json
+++ b/settings.json
@@ -217,22 +217,6 @@
             "loop_delay": 0.01,
             "startup_delay": 1,
             "specifications": {
-                "memory_map_chunk": [
-                    {
-                        "name": "id",
-                        "format": "B",
-                        "value": 1,
-                        "private": false
-                    },
-                    {
-                        "name": "latitude",
-                        "format": "d"
-                    },
-                    {
-                        "name": "longitude",
-                        "format": "d"
-                    }
-                ],
                 "rssi_broadcast": [
                     {
                         "name": "id",

--- a/settings.json
+++ b/settings.json
@@ -411,7 +411,7 @@
         "name": "XBee TDMA scheduler",
         "parent": "xbee_base",
         "settings": {
-            "sweep_delay": 0.5
+            "sweep_delay": 0.4
         }
     }
 }

--- a/settings.json
+++ b/settings.json
@@ -214,7 +214,6 @@
             "number_of_sensors": 2,
             "xbee_id": 0,
             "custom_packet_delay": 0.1,
-            "custom_packet_limit": 1,
             "loop_delay": 0.01,
             "startup_delay": 1,
             "specifications": {

--- a/tests/xbee_packet.py
+++ b/tests/xbee_packet.py
@@ -29,7 +29,7 @@ class TestXBeePacket(unittest.TestCase):
 
         # When a valid specification is set, the private property
         # must be updated.
-        self.packet.set("specification", "memory_map_chunk")
+        self.packet.set("specification", "waypoint_add")
         self.assertFalse(self.packet._private)
 
     def test_unset(self):
@@ -70,17 +70,19 @@ class TestXBeePacket(unittest.TestCase):
             self.packet.serialize()
 
         # All fields from the specification must be provided.
-        self.packet.set("specification", "memory_map_chunk")
+        self.packet.set("specification", "waypoint_add")
         with self.assertRaises(KeyError):
             self.packet.serialize()
 
         # When all fields are provided, the specification field must be
         # unset and the packed message must be valid.
-        self.packet.set("specification", "memory_map_chunk")
+        self.packet.set("specification", "waypoint_add")
         self.packet.set("latitude", 123456789.12)
         self.packet.set("longitude", 123496785.34)
+        self.packet.set("index", 22)
+        self.packet.set("to_id", 2)
         packed_message = self.packet.serialize()
-        self.assertEqual(packed_message, "\x01H\xe1zT4o\x9dA\xf6(\\E\xa5q\x9dA")
+        self.assertEqual(packed_message, "\x06H\xe1zT4o\x9dA\xf6(\\E\xa5q\x9dA\x16\x00\x00\x00\x02")
 
     def test_unserialize(self):
         # Empty strings must be refused.
@@ -92,11 +94,13 @@ class TestXBeePacket(unittest.TestCase):
             self.packet.unserialize("\xFF\x01")
 
         # Valid messages must be unpacked.
-        self.packet.unserialize("\x01H\xe1zT4o\x9dA\xf6(\\E\xa5q\x9dA")
+        self.packet.unserialize("\x06H\xe1zT4o\x9dA\xf6(\\E\xa5q\x9dA\x16\x00\x00\x00\x02")
         self.assertEqual(self.packet._contents, {
-            "specification": "memory_map_chunk",
+            "specification": "waypoint_add",
             "latitude": 123456789.12,
-            "longitude": 123496785.34
+            "longitude": 123496785.34,
+            "index": 22,
+            "to_id": 2
         })
         self.assertFalse(self.packet._private)
 

--- a/tests/xbee_sensor_physical.py
+++ b/tests/xbee_sensor_physical.py
@@ -49,7 +49,7 @@ class TestXBeeSensorPhysical(USBManagerTestCase, ThreadableTestCase, SettingsTes
         self.sensor._id = self.sensor_id
 
     def test_initialization(self):
-        self.assertEqual(self.sensor._id, self.sensor_id)
+        self.assertEqual(self.sensor.id, self.sensor_id)
         self.assertTrue(hasattr(self.sensor._location_callback, "__call__"))
         self.assertTrue(hasattr(self.sensor._receive_callback, "__call__"))
         self.assertTrue(hasattr(self.sensor._valid_callback, "__call__"))
@@ -321,7 +321,7 @@ class TestXBeeSensorPhysical(USBManagerTestCase, ThreadableTestCase, SettingsTes
             "parameter": "4"
         }
         self.sensor._receive(raw_packet)
-        self.assertEqual(self.sensor._id, 4)
+        self.assertEqual(self.sensor.id, 4)
         self.assertEqual(self.sensor._scheduler.id, 4)
         self.assertEqual(self.sensor._node_identifier_set, True)
 

--- a/tests/xbee_sensor_physical.py
+++ b/tests/xbee_sensor_physical.py
@@ -114,9 +114,11 @@ class TestXBeeSensorPhysical(USBManagerTestCase, ThreadableTestCase, SettingsTes
         # Packets that do not contain a destination should be broadcasted.
         # We subtract one because we do not send to ourself.
         packet = XBee_Packet()
-        packet.set("specification", "memory_map_chunk")
+        packet.set("specification", "waypoint_add")
         packet.set("latitude", 123456789.12)
         packet.set("longitude", 123459678.34)
+        packet.set("index", 22)
+        packet.set("to_id", 2)
         self.sensor.enqueue(packet)
         self.assertEqual(self.sensor._queue.qsize(),
                          self.settings.get("number_of_sensors") - 1)
@@ -124,9 +126,11 @@ class TestXBeeSensorPhysical(USBManagerTestCase, ThreadableTestCase, SettingsTes
 
         # Valid packets should be enqueued.
         packet = XBee_Packet()
-        packet.set("specification", "memory_map_chunk")
+        packet.set("specification", "waypoint_add")
         packet.set("latitude", 123456789.12)
         packet.set("longitude", 123459678.34)
+        packet.set("index", 22)
+        packet.set("to_id", 2)
         self.sensor.enqueue(packet, to=2)
         self.assertEqual(self.sensor._queue.get(), {
             "packet": packet,
@@ -200,9 +204,11 @@ class TestXBeeSensorPhysical(USBManagerTestCase, ThreadableTestCase, SettingsTes
 
         # If the queue contains custom packets, some of them must be sent.
         packet = XBee_Packet()
-        packet.set("specification", "memory_map_chunk")
+        packet.set("specification", "waypoint_add")
         packet.set("latitude", 123456789.12)
         packet.set("longitude", 123459678.34)
+        packet.set("index", 22)
+        packet.set("to_id", 2)
         self.sensor.enqueue(packet, to=2)
 
         queue_length = self.sensor._queue.qsize()

--- a/tests/xbee_sensor_physical.py
+++ b/tests/xbee_sensor_physical.py
@@ -205,12 +205,10 @@ class TestXBeeSensorPhysical(USBManagerTestCase, ThreadableTestCase, SettingsTes
         packet.set("longitude", 123459678.34)
         self.sensor.enqueue(packet, to=2)
 
-        queue_length_before = self.sensor._queue.qsize()
+        queue_length = self.sensor._queue.qsize()
         self.sensor._send_custom_packets()
-        custom_packet_limit = self.settings.get("custom_packet_limit")
-        queue_length_after = max(0, queue_length_before - custom_packet_limit)
-        self.assertEqual(mock_send.call_count, (queue_length_before - queue_length_after))
-        self.assertEqual(self.sensor._queue.qsize(), queue_length_after)
+        self.assertEqual(mock_send.call_count, queue_length)
+        self.assertEqual(self.sensor._queue.qsize(), 0)
 
         self.sensor.deactivate()
 

--- a/tests/xbee_sensor_simulator.py
+++ b/tests/xbee_sensor_simulator.py
@@ -54,7 +54,7 @@ class TestXBeeSensorSimulator(ThreadableTestCase, SettingsTestCase):
 
     def test_initialization(self):
         # The ID of the sensor must be set.
-        self.assertEqual(self.sensor._id, self.sensor_id)
+        self.assertEqual(self.sensor.id, self.sensor_id)
 
         # The next timestamp must be zero.
         self.assertEqual(self.sensor._next_timestamp, 0)

--- a/tests/xbee_sensor_simulator.py
+++ b/tests/xbee_sensor_simulator.py
@@ -128,11 +128,8 @@ class TestXBeeSensorSimulator(ThreadableTestCase, SettingsTestCase):
         packet.set("longitude", 123459678.34)
         self.sensor.enqueue(packet, to=2)
 
-        queue_length_before = self.sensor._queue.qsize()
         self.sensor._send_custom_packets()
-        custom_packet_limit = self.settings.get("custom_packet_limit")
-        queue_length_after = max(0, queue_length_before - custom_packet_limit)
-        self.assertEqual(self.sensor._queue.qsize(), queue_length_after)
+        self.assertEqual(self.sensor._queue.qsize(), 0)
 
     def test_receive(self):
         # Create a packet from sensor 2 to the current sensor.

--- a/tests/xbee_sensor_simulator.py
+++ b/tests/xbee_sensor_simulator.py
@@ -96,9 +96,11 @@ class TestXBeeSensorSimulator(ThreadableTestCase, SettingsTestCase):
         # Packets that do not contain a destination should be broadcasted.
         # We subtract one because we do not send to ourself.
         packet = XBee_Packet()
-        packet.set("specification", "memory_map_chunk")
+        packet.set("specification", "waypoint_add")
         packet.set("latitude", 123456789.12)
         packet.set("longitude", 123459678.34)
+        packet.set("index", 22)
+        packet.set("to_id", 2)
         self.sensor.enqueue(packet)
         self.assertEqual(self.sensor._queue.qsize(),
                          self.settings.get("number_of_sensors") - 1)
@@ -106,9 +108,11 @@ class TestXBeeSensorSimulator(ThreadableTestCase, SettingsTestCase):
 
         # Valid packets should be enqueued.
         packet = XBee_Packet()
-        packet.set("specification", "memory_map_chunk")
+        packet.set("specification", "waypoint_add")
         packet.set("latitude", 123456789.12)
         packet.set("longitude", 123459678.34)
+        packet.set("index", 22)
+        packet.set("to_id", 2)
         self.sensor.enqueue(packet, to=2)
         self.assertEqual(self.sensor._queue.get(), {
             "packet": packet,
@@ -123,9 +127,11 @@ class TestXBeeSensorSimulator(ThreadableTestCase, SettingsTestCase):
     def test_send_custom_packets(self):
         # If the queue contains packets, some of them must be sent.
         packet = XBee_Packet()
-        packet.set("specification", "memory_map_chunk")
+        packet.set("specification", "waypoint_add")
         packet.set("latitude", 123456789.12)
         packet.set("longitude", 123459678.34)
+        packet.set("index", 22)
+        packet.set("to_id", 2)
         self.sensor.enqueue(packet, to=2)
 
         self.sensor._send_custom_packets()

--- a/trajectory/Mission.py
+++ b/trajectory/Mission.py
@@ -885,7 +885,7 @@ class Mission_XBee(Mission_Auto):
 
     def _complete_waypoints(self, packet):
         xbee_sensor = self.environment.get_xbee_sensor()
-        if xbee_sensor.id != packet.get("to_id"):
+        if xbee_sensor._id != packet.get("to_id"):
             # Ignore packets not meant for us.
             return
 
@@ -910,7 +910,7 @@ class Mission_XBee(Mission_Auto):
         ack_packet = XBee_Packet()
         ack_packet.set("specification", "waypoint_ack")
         ack_packet.set("next_index", self.vehicle.count_waypoints())
-        ack_packet.set("sensor_id", xbee_sensor.id)
+        ack_packet.set("sensor_id", xbee_sensor._id)
 
         xbee_sensor.enqueue(ack_packet, to=0)
 
@@ -920,7 +920,7 @@ class Mission_XBee(Mission_Auto):
         """
 
         xbee_sensor = self.environment.get_xbee_sensor()
-        if xbee_sensor.id != packet.get("to_id"):
+        if xbee_sensor._id != packet.get("to_id"):
             # Ignore packets not meant for us.
             return
 
@@ -937,7 +937,7 @@ class Mission_XBee(Mission_Auto):
         """
 
         xbee_sensor = self.environment.get_xbee_sensor()
-        if xbee_sensor.id != packet.get("to_id"):
+        if xbee_sensor._id != packet.get("to_id"):
             # Ignore packets not meant for us.
             return
 

--- a/trajectory/Mission.py
+++ b/trajectory/Mission.py
@@ -885,7 +885,7 @@ class Mission_XBee(Mission_Auto):
 
     def _complete_waypoints(self, packet):
         xbee_sensor = self.environment.get_xbee_sensor()
-        if xbee_sensor._id != packet.get("to_id"):
+        if xbee_sensor.id != packet.get("to_id"):
             # Ignore packets not meant for us.
             return
 
@@ -910,7 +910,7 @@ class Mission_XBee(Mission_Auto):
         ack_packet = XBee_Packet()
         ack_packet.set("specification", "waypoint_ack")
         ack_packet.set("next_index", self.vehicle.count_waypoints())
-        ack_packet.set("sensor_id", xbee_sensor._id)
+        ack_packet.set("sensor_id", xbee_sensor.id)
 
         xbee_sensor.enqueue(ack_packet, to=0)
 
@@ -920,7 +920,7 @@ class Mission_XBee(Mission_Auto):
         """
 
         xbee_sensor = self.environment.get_xbee_sensor()
-        if xbee_sensor._id != packet.get("to_id"):
+        if xbee_sensor.id != packet.get("to_id"):
             # Ignore packets not meant for us.
             return
 
@@ -937,7 +937,7 @@ class Mission_XBee(Mission_Auto):
         """
 
         xbee_sensor = self.environment.get_xbee_sensor()
-        if xbee_sensor._id != packet.get("to_id"):
+        if xbee_sensor.id != packet.get("to_id"):
             # Ignore packets not meant for us.
             return
 

--- a/trajectory/Monitor.py
+++ b/trajectory/Monitor.py
@@ -85,9 +85,6 @@ class Monitor(object):
 
             i = i + 1
 
-        if xbee_sensor:
-            xbee_sensor.activate()
-
         # Display the current memory map interactively.
         if self.plot:
             self.plot.plot_lines(self.mission.get_waypoints())

--- a/trajectory/Monitor.py
+++ b/trajectory/Monitor.py
@@ -105,12 +105,19 @@ class Monitor(object):
     def sleep(self):
         time.sleep(self.step_delay)
 
+    def start(self):
+        self.mission.start()
+
+        xbee_sensor = self.environment.get_xbee_sensor()
+        if xbee_sensor is not None:
+            xbee_sensor.start()
+
     def stop(self):
         self.mission.stop()
 
         xbee_sensor = self.environment.get_xbee_sensor()
         if xbee_sensor is not None:
-            xbee_sensor.deactivate()
+            xbee_sensor.stop()
 
         if self.plot:
             self.plot.close()

--- a/trajectory/Monitor.py
+++ b/trajectory/Monitor.py
@@ -1,6 +1,4 @@
 import time
-from dronekit import LocationGlobalRelative
-from ..zigbee.XBee_Packet import XBee_Packet
 
 class Monitor(object):
     """
@@ -33,7 +31,6 @@ class Monitor(object):
         return self.settings.get("viewer")
 
     def setup(self):
-        self.environment.add_packet_action("memory_map_chunk", self.add_memory_map)
         self.memory_map = self.mission.get_memory_map()
 
         if self.settings.get("plot"):
@@ -83,12 +80,6 @@ class Monitor(object):
                     # the angle's direction. This is again a "cheat" for 
                     # checking if walls get visualized correctly.
                     sensor.draw_current_edge(self.plot.get_plot(), self.memory_map, self.colors[i % len(self.colors)])
-                if xbee_sensor:
-                    packet = XBee_Packet()
-                    packet.set("specification", "memory_map_chunk")
-                    packet.set("latitude", location.lat)
-                    packet.set("longitude", location.lon)
-                    xbee_sensor.enqueue(packet)
 
                 print("=== [!] Distance to object: {} m (yaw {}, pitch {}) ===".format(sensor_distance, yaw, pitch))
 
@@ -116,15 +107,6 @@ class Monitor(object):
 
     def sleep(self):
         time.sleep(self.step_delay)
-
-    def add_memory_map(self, packet):
-        loc = LocationGlobalRelative(packet.get("latitude"), packet.get("longitude"), 0.0)
-        idx = self.memory_map.get_index(loc)
-        print("Received location {}, index {} from other vehicle".format(loc, idx))
-        try:
-            self.memory_map.set(idx, 1)
-        except KeyError:
-            pass
 
     def stop(self):
         self.mission.stop()

--- a/xbee_sensor_physical.py
+++ b/xbee_sensor_physical.py
@@ -41,14 +41,15 @@ def main(argv):
         xbee_sensor.activate()
 
         # Enqueue a custom packet.
-        packet = XBee_Packet()
-        packet.set("specification", "waypoint_add")
-        packet.set("latitude", 123456789.12)
-        packet.set("longitude", 123459678.34)
-        packet.set("index", 22)
-        packet.set("to_id", 2)
-        xbee_sensor.enqueue(packet)
-        time.sleep(1)
+        if xbee_sensor._id == 0:
+            packet = XBee_Packet()
+            packet.set("specification", "waypoint_add")
+            packet.set("latitude", 123456789.12)
+            packet.set("longitude", 123459678.34)
+            packet.set("index", 22)
+            packet.set("to_id", 2)
+            xbee_sensor.enqueue(packet)
+            time.sleep(1)
 
         # Start the signal strength measurements.
         xbee_sensor.start()

--- a/xbee_sensor_physical.py
+++ b/xbee_sensor_physical.py
@@ -5,7 +5,6 @@ from __init__ import __package__
 from core.Thread_Manager import Thread_Manager
 from core.USB_Manager import USB_Manager
 from settings import Arguments
-from zigbee.XBee_Packet import XBee_Packet
 from zigbee.XBee_Sensor_Physical import XBee_Sensor_Physical
 
 def get_location():
@@ -20,7 +19,7 @@ def receive_packet(packet):
     Handle a custom packet that has been sent to this sensor.
     """
 
-    print("> Custom packet received: {}".format(packet.get_all()))
+    pass
 
 def location_valid(other_valid=None):
     return True
@@ -39,19 +38,6 @@ def main(argv):
         arguments.check_help()
 
         xbee_sensor.activate()
-
-        # Enqueue a custom packet.
-        if xbee_sensor._id == 0:
-            packet = XBee_Packet()
-            packet.set("specification", "waypoint_add")
-            packet.set("latitude", 123456789.12)
-            packet.set("longitude", 123459678.34)
-            packet.set("index", 22)
-            packet.set("to_id", 2)
-            xbee_sensor.enqueue(packet)
-            time.sleep(1)
-
-        # Start the signal strength measurements.
         xbee_sensor.start()
 
         while True:

--- a/xbee_sensor_physical.py
+++ b/xbee_sensor_physical.py
@@ -5,7 +5,6 @@ from __init__ import __package__
 from core.Thread_Manager import Thread_Manager
 from core.USB_Manager import USB_Manager
 from settings import Arguments
-from zigbee.XBee_Packet import XBee_Packet
 from zigbee.XBee_Sensor_Physical import XBee_Sensor_Physical
 
 def get_location():
@@ -40,17 +39,7 @@ def main(argv):
 
         xbee_sensor.activate()
 
-        timestamp = 0
         while True:
-            # Enqueue a custom packet at a fixed interval.
-            if xbee_sensor._id > 0 and time.time() > timestamp:
-                timestamp = time.time() + 8
-                packet = XBee_Packet()
-                packet.set("specification", "memory_map_chunk")
-                packet.set("latitude", 123456789.12)
-                packet.set("longitude", 123495678.34)
-                xbee_sensor.enqueue(packet)
-
             time.sleep(1)
     except:
         thread_manager.destroy()

--- a/xbee_sensor_physical.py
+++ b/xbee_sensor_physical.py
@@ -5,6 +5,7 @@ from __init__ import __package__
 from core.Thread_Manager import Thread_Manager
 from core.USB_Manager import USB_Manager
 from settings import Arguments
+from zigbee.XBee_Packet import XBee_Packet
 from zigbee.XBee_Sensor_Physical import XBee_Sensor_Physical
 
 def get_location():
@@ -38,6 +39,19 @@ def main(argv):
         arguments.check_help()
 
         xbee_sensor.activate()
+
+        # Enqueue a custom packet.
+        packet = XBee_Packet()
+        packet.set("specification", "waypoint_add")
+        packet.set("latitude", 123456789.12)
+        packet.set("longitude", 123459678.34)
+        packet.set("index", 22)
+        packet.set("to_id", 2)
+        xbee_sensor.enqueue(packet)
+        time.sleep(1)
+
+        # Start the signal strength measurements.
+        xbee_sensor.start()
 
         while True:
             time.sleep(1)

--- a/xbee_sensor_simulator.py
+++ b/xbee_sensor_simulator.py
@@ -4,6 +4,7 @@ import random
 from __init__ import __package__
 from core.Thread_Manager import Thread_Manager
 from settings import Arguments
+from zigbee.XBee_Packet import XBee_Packet
 from zigbee.XBee_Sensor_Simulator import XBee_Sensor_Simulator
 
 def get_location():
@@ -35,6 +36,19 @@ def main(argv):
         arguments.check_help()
 
         xbee_sensor.activate()
+
+        # Enqueue a custom packet.
+        packet = XBee_Packet()
+        packet.set("specification", "waypoint_add")
+        packet.set("latitude", 123456789.12)
+        packet.set("longitude", 123459678.34)
+        packet.set("index", 22)
+        packet.set("to_id", 2)
+        xbee_sensor.enqueue(packet)
+        time.sleep(1)
+
+        # Start the signal strength measurements.
+        xbee_sensor.start()
 
         while True:
             time.sleep(1)

--- a/xbee_sensor_simulator.py
+++ b/xbee_sensor_simulator.py
@@ -4,7 +4,6 @@ import random
 from __init__ import __package__
 from core.Thread_Manager import Thread_Manager
 from settings import Arguments
-from zigbee.XBee_Packet import XBee_Packet
 from zigbee.XBee_Sensor_Simulator import XBee_Sensor_Simulator
 
 def get_location():
@@ -19,7 +18,7 @@ def receive_packet(packet):
     Handle a custom packet that has been sent to this sensor.
     """
 
-    print("> Custom packet received: {}".format(packet.get_all()))
+    pass
 
 def location_valid(other_valid=None):
     return True
@@ -36,19 +35,6 @@ def main(argv):
         arguments.check_help()
 
         xbee_sensor.activate()
-
-        # Enqueue a custom packet.
-        if xbee_sensor._id == 0:
-            packet = XBee_Packet()
-            packet.set("specification", "waypoint_add")
-            packet.set("latitude", 123456789.12)
-            packet.set("longitude", 123459678.34)
-            packet.set("index", 22)
-            packet.set("to_id", 2)
-            xbee_sensor.enqueue(packet)
-            time.sleep(1)
-
-        # Start the signal strength measurements.
         xbee_sensor.start()
 
         while True:

--- a/xbee_sensor_simulator.py
+++ b/xbee_sensor_simulator.py
@@ -4,7 +4,6 @@ import random
 from __init__ import __package__
 from core.Thread_Manager import Thread_Manager
 from settings import Arguments
-from zigbee.XBee_Packet import XBee_Packet
 from zigbee.XBee_Sensor_Simulator import XBee_Sensor_Simulator
 
 def get_location():
@@ -37,17 +36,7 @@ def main(argv):
 
         xbee_sensor.activate()
 
-        timestamp = 0
         while True:
-            # Enqueue a custom packet at a fixed interval.
-            if xbee_sensor._id > 0 and time.time() > timestamp:
-                timestamp = time.time() + 8
-                packet = XBee_Packet()
-                packet.set("specification", "memory_map_chunk")
-                packet.set("latitude", 123456789.12)
-                packet.set("longitude", 123495678.34)
-                xbee_sensor.enqueue(packet)
-
             time.sleep(1)
     except:
         thread_manager.destroy()

--- a/xbee_sensor_simulator.py
+++ b/xbee_sensor_simulator.py
@@ -38,14 +38,15 @@ def main(argv):
         xbee_sensor.activate()
 
         # Enqueue a custom packet.
-        packet = XBee_Packet()
-        packet.set("specification", "waypoint_add")
-        packet.set("latitude", 123456789.12)
-        packet.set("longitude", 123459678.34)
-        packet.set("index", 22)
-        packet.set("to_id", 2)
-        xbee_sensor.enqueue(packet)
-        time.sleep(1)
+        if xbee_sensor._id == 0:
+            packet = XBee_Packet()
+            packet.set("specification", "waypoint_add")
+            packet.set("latitude", 123456789.12)
+            packet.set("longitude", 123459678.34)
+            packet.set("index", 22)
+            packet.set("to_id", 2)
+            xbee_sensor.enqueue(packet)
+            time.sleep(1)
 
         # Start the signal strength measurements.
         xbee_sensor.start()

--- a/zigbee/XBee_Sensor.py
+++ b/zigbee/XBee_Sensor.py
@@ -58,6 +58,7 @@ class XBee_Sensor(Threadable):
         self._data = {}
         self._queue = Queue.Queue()
         self._loop_delay = self._settings.get("loop_delay")
+        self._custom_packet_delay = self._settings.get("custom_packet_delay")
         self._active = False
         self._joined = False
         self._started = False

--- a/zigbee/XBee_Sensor.py
+++ b/zigbee/XBee_Sensor.py
@@ -136,7 +136,13 @@ class XBee_Sensor(Threadable):
         raise NotImplementedError("Subclasses must implement `_send()`")
 
     def _send_custom_packets(self):
-        raise NotImplementedError("Subclasses must implement `_send_custom_packets()`")
+        """
+        Send custom packets to their destinations.
+        """
+
+        while not self._queue.empty():
+            item = self._queue.get()
+            self._send_tx_frame(item["packet"], item["to"])
 
     def _send_tx_frame(self, packet, to=None):
         raise NotImplementedError("Subclasses must implement `_send_tx_frame(packet, to=None)`")

--- a/zigbee/XBee_Sensor.py
+++ b/zigbee/XBee_Sensor.py
@@ -144,7 +144,7 @@ class XBee_Sensor(Threadable):
     def _format_address(self, address):
         raise NotImplementedError("Subclasses must implement `_format_address(address)`")
 
-    def check_receive(self, packet):
+    def _check_receive(self, packet):
         """
         Check whether the given `packet` should be given to the receive callback
         rather than handling it internally.
@@ -159,7 +159,7 @@ class XBee_Sensor(Threadable):
 
         return False
 
-    def make_rssi_broadcast_packet(self):
+    def _make_rssi_broadcast_packet(self):
         """
         Create an XBee_Packet object containing current location data.
 
@@ -176,7 +176,7 @@ class XBee_Sensor(Threadable):
 
         return packet
 
-    def make_rssi_ground_station_packet(self, rssi_packet):
+    def _make_rssi_ground_station_packet(self, rssi_packet):
         """
         Create an XBee_Packet object containing location data of the current
         XBee and data from an XBee_Packet `rssi_packet`. The `rssi_packet`

--- a/zigbee/XBee_Sensor.py
+++ b/zigbee/XBee_Sensor.py
@@ -145,7 +145,15 @@ class XBee_Sensor(Threadable):
             self._send_tx_frame(item["packet"], item["to"])
 
     def _send_tx_frame(self, packet, to=None):
-        raise NotImplementedError("Subclasses must implement `_send_tx_frame(packet, to=None)`")
+        """
+        Send a TX frame to another sensor.
+        """
+
+        if not isinstance(packet, XBee_Packet):
+            raise ValueError("Invalid packet specified")
+
+        if to is None:
+            raise ValueError("Invalid destination specified: {}".format(to))
 
     def _receive(self, packet):
         raise NotImplementedError("Subclasses must implement `_receive(packet)`")

--- a/zigbee/XBee_Sensor.py
+++ b/zigbee/XBee_Sensor.py
@@ -68,6 +68,10 @@ class XBee_Sensor(Threadable):
         self._receive_callback = receive_callback
         self._valid_callback = valid_callback
 
+    @property
+    def id(self):
+        return self._id
+
     def get_identity(self):
         """
         Get the identity (ID, address and join status) of this sensor.

--- a/zigbee/XBee_Sensor.py
+++ b/zigbee/XBee_Sensor.py
@@ -60,6 +60,7 @@ class XBee_Sensor(Threadable):
         self._loop_delay = self._settings.get("loop_delay")
         self._active = False
         self._joined = False
+        self._started = False
 
         self._usb_manager = usb_manager
         self._location_callback = location_callback
@@ -80,6 +81,20 @@ class XBee_Sensor(Threadable):
 
     def setup(self):
         raise NotImplementedError("Subclasses must implement `setup()`")
+
+    def start(self):
+        """
+        Start the signal strength measurements (and no longer send custom packets).
+        """
+
+        self._started = True
+
+    def stop(self):
+        """
+        Stop the signal strength measurements (and send custom packets).
+        """
+
+        self._started = False
 
     def _loop(self):
         raise NotImplementedError("Subclasses must implement `_loop()`")

--- a/zigbee/XBee_Sensor.py
+++ b/zigbee/XBee_Sensor.py
@@ -138,6 +138,9 @@ class XBee_Sensor(Threadable):
     def _send_custom_packets(self):
         raise NotImplementedError("Subclasses must implement `_send_custom_packets()`")
 
+    def _send_tx_frame(self, packet, to=None):
+        raise NotImplementedError("Subclasses must implement `_send_tx_frame(packet, to=None)`")
+
     def _receive(self, packet):
         raise NotImplementedError("Subclasses must implement `_receive(packet)`")
 

--- a/zigbee/XBee_Sensor_Physical.py
+++ b/zigbee/XBee_Sensor_Physical.py
@@ -205,11 +205,6 @@ class XBee_Sensor_Physical(XBee_Sensor):
                               dest_addr="\xFF\xFE", frame_id="\x00",
                               data=packet.serialize())
 
-        # Send custom packets to their destinations. Since the time slots
-        # are limited in length, so is the number of custom packets we
-        # send in each sweep.
-        self._send_custom_packets()
-
         # Send the sweep data to the ground sensor and clear the list
         # for the next round.
         for frame_id in self._data.keys():

--- a/zigbee/XBee_Sensor_Physical.py
+++ b/zigbee/XBee_Sensor_Physical.py
@@ -219,11 +219,7 @@ class XBee_Sensor_Physical(XBee_Sensor):
         Send a TX frame to another sensor.
         """
 
-        if not isinstance(packet, XBee_Packet):
-            raise ValueError("Invalid packet specified")
-
-        if to is None:
-            raise ValueError("Invalid destination specified: {}".format(to))
+        super(XBee_Sensor_Physical, self)._send_tx_frame(packet, to)
 
         self._sensor.send("tx", dest_addr_long=self._sensors[to], dest_addr="\xFF\xFE",
                           frame_id="\x00", data=packet.serialize())

--- a/zigbee/XBee_Sensor_Physical.py
+++ b/zigbee/XBee_Sensor_Physical.py
@@ -197,7 +197,7 @@ class XBee_Sensor_Physical(XBee_Sensor):
         """
 
         # Create and send the RSSI broadcast packets.
-        packet = self.make_rssi_broadcast_packet()
+        packet = self._make_rssi_broadcast_packet()
         packet.set("sensor_id", self._id)
 
         for index in xrange(1, self._number_of_sensors + 1):
@@ -241,7 +241,7 @@ class XBee_Sensor_Physical(XBee_Sensor):
             packet = XBee_Packet()
             packet.unserialize(raw_packet["rf_data"])
 
-            if self.check_receive(packet):
+            if self._check_receive(packet):
                 return
 
             if packet.get("specification") == "ntp":
@@ -265,7 +265,7 @@ class XBee_Sensor_Physical(XBee_Sensor):
             self._next_timestamp = self._scheduler.synchronize(packet)
 
             # Create the packet for the ground station.
-            ground_station_packet = self.make_rssi_ground_station_packet(packet)
+            ground_station_packet = self._make_rssi_ground_station_packet(packet)
 
             # Generate a frame ID to be able to match this packet and the
             # associated RSSI (DB command) request.

--- a/zigbee/XBee_Sensor_Physical.py
+++ b/zigbee/XBee_Sensor_Physical.py
@@ -27,7 +27,6 @@ class XBee_Sensor_Physical(XBee_Sensor):
 
         # Prepare the packet and sensor data.
         self._custom_packet_delay = self._settings.get("custom_packet_delay")
-        self._custom_packet_limit = self._settings.get("custom_packet_limit")
         self._number_of_sensors = self._settings.get("number_of_sensors")
         self._sensors = self._settings.get("sensors")
         for index, address in enumerate(self._sensors):
@@ -227,12 +226,7 @@ class XBee_Sensor_Physical(XBee_Sensor):
         Send custom packets to their destinations.
         """
 
-        limit = self._custom_packet_limit
         while not self._queue.empty():
-            if limit == 0:
-                break
-
-            limit -= 1
             item = self._queue.get()
             self._sensor.send("tx", dest_addr_long=self._sensors[item["to"]],
                               dest_addr="\xFF\xFE", frame_id="\x00",

--- a/zigbee/XBee_Sensor_Physical.py
+++ b/zigbee/XBee_Sensor_Physical.py
@@ -214,15 +214,6 @@ class XBee_Sensor_Physical(XBee_Sensor):
             self._send_tx_frame(packet, 0)
             self._data.pop(frame_id)
 
-    def _send_custom_packets(self):
-        """
-        Send custom packets to their destinations.
-        """
-
-        while not self._queue.empty():
-            item = self._queue.get()
-            self._send_tx_frame(item["packet"], item["to"])
-
     def _send_tx_frame(self, packet, to=None):
         """
         Send a TX frame to another sensor.

--- a/zigbee/XBee_Sensor_Physical.py
+++ b/zigbee/XBee_Sensor_Physical.py
@@ -85,7 +85,8 @@ class XBee_Sensor_Physical(XBee_Sensor):
                 elif self._id > 0 and time.time() >= self._next_timestamp:
                     self._next_timestamp = self._scheduler.get_next_timestamp()
                     self._send()
-                    time.sleep(self._loop_delay)
+
+                time.sleep(self._loop_delay)
         except:
             super(XBee_Sensor_Physical, self).interrupt()
 

--- a/zigbee/XBee_Sensor_Physical.py
+++ b/zigbee/XBee_Sensor_Physical.py
@@ -49,8 +49,7 @@ class XBee_Sensor_Physical(XBee_Sensor):
 
     def activate(self):
         """
-        Activate the sensor by sending a packet if it is not a ground station.
-        The sensor always receives packets asynchronously.
+        Activate the sensor to send and receive packets.
         """
 
         super(XBee_Sensor_Physical, self).activate()

--- a/zigbee/XBee_Sensor_Physical.py
+++ b/zigbee/XBee_Sensor_Physical.py
@@ -26,7 +26,6 @@ class XBee_Sensor_Physical(XBee_Sensor):
         self._synchronized = False
 
         # Prepare the packet and sensor data.
-        self._custom_packet_delay = self._settings.get("custom_packet_delay")
         self._number_of_sensors = self._settings.get("number_of_sensors")
         self._sensors = self._settings.get("sensors")
         for index, address in enumerate(self._sensors):

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -34,7 +34,6 @@ class XBee_Sensor_Simulator(XBee_Sensor):
     def activate(self):
         """
         Activate the sensor to send and receive packets.
-        The ground sensor (with ID 0) can only receive packets.
         """
 
         super(XBee_Sensor_Simulator, self).activate()

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -115,11 +115,6 @@ class XBee_Sensor_Simulator(XBee_Sensor):
             packet.set("sensor_id", self._id)
             self._sensor.sendto(packet.serialize(), (self._ip, self._port + i))
 
-        # Send custom packets to their destination. Since the time slots are
-        # limited in length, so is the number of custom packets we transfer
-        # in each sweep.
-        self._send_custom_packets()
-
         # Send the sweep data to the ground sensor.
         for frame_id in self._data.keys():
             packet = self._data[frame_id]

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -132,12 +132,7 @@ class XBee_Sensor_Simulator(XBee_Sensor):
         Send custom packets to their destinations.
         """
 
-        limit = self._settings.get("custom_packet_limit")
         while not self._queue.empty():
-            if limit == 0:
-                break
-
-            limit -= 1
             item = self._queue.get()
             self._sensor.sendto(item["packet"].serialize(), (self._ip, self._port + item["to"]))
 

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -119,12 +119,12 @@ class XBee_Sensor_Simulator(XBee_Sensor):
 
             packet = self._make_rssi_broadcast_packet()
             packet.set("sensor_id", self._id)
-            self._sensor.sendto(packet.serialize(), (self._ip, self._port + i))
+            self._send_tx_frame(packet, i)
 
         # Send the sweep data to the ground sensor.
         for frame_id in self._data.keys():
             packet = self._data[frame_id]
-            self._sensor.sendto(packet.serialize(), (self._ip, self._port))
+            self._send_tx_frame(packet, 0)
             self._data.pop(frame_id)
 
     def _send_custom_packets(self):
@@ -134,7 +134,20 @@ class XBee_Sensor_Simulator(XBee_Sensor):
 
         while not self._queue.empty():
             item = self._queue.get()
-            self._sensor.sendto(item["packet"].serialize(), (self._ip, self._port + item["to"]))
+            self._send_tx_frame(item["packet"], item["to"])
+
+    def _send_tx_frame(self, packet, to=None):
+        """
+        Send a TX frame to another sensor.
+        """
+
+        if not isinstance(packet, XBee_Packet):
+            raise ValueError("Invalid packet specified")
+
+        if to is None:
+            raise ValueError("Invalid destination specified: {}".format(to))
+
+        self._sensor.sendto(packet.serialize(), (self._ip, self._port + to))
 
     def _receive(self, packet):
         """

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -132,11 +132,7 @@ class XBee_Sensor_Simulator(XBee_Sensor):
         Send a TX frame to another sensor.
         """
 
-        if not isinstance(packet, XBee_Packet):
-            raise ValueError("Invalid packet specified")
-
-        if to is None:
-            raise ValueError("Invalid destination specified: {}".format(to))
+        super(XBee_Sensor_Simulator, self)._send_tx_frame(packet, to)
 
         self._sensor.sendto(packet.serialize(), (self._ip, self._port + to))
 

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -53,9 +53,17 @@ class XBee_Sensor_Simulator(XBee_Sensor):
 
         try:
             while self._active:
-                if self._id > 0 and time.time() >= self._next_timestamp:
+                # If the sensor has been activated, this loop will only send
+                # enqueued custom packets. If the sensor has been started, we
+                # stop sending custom packets and start performing signal
+                # strength measurements.
+                if not self._started:
+                    self._send_custom_packets()
+                    time.sleep(self._custom_packet_delay)
+                elif self._id > 0 and time.time() >= self._next_timestamp:
                     self._next_timestamp = self._scheduler.get_next_timestamp()
                     self._send()
+                    time.sleep(self._loop_delay)
 
                 # Check if there is data to be processed.
                 try:
@@ -68,8 +76,6 @@ class XBee_Sensor_Simulator(XBee_Sensor):
                 packet = XBee_Packet()
                 packet.unserialize(data)
                 self._receive(packet)
-
-                time.sleep(self._loop_delay)
         except:
             super(XBee_Sensor_Simulator, self).interrupt()
 

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -117,7 +117,7 @@ class XBee_Sensor_Simulator(XBee_Sensor):
             if i == self._id:
                 continue
 
-            packet = self.make_rssi_broadcast_packet()
+            packet = self._make_rssi_broadcast_packet()
             packet.set("sensor_id", self._id)
             self._sensor.sendto(packet.serialize(), (self._ip, self._port + i))
 
@@ -141,12 +141,12 @@ class XBee_Sensor_Simulator(XBee_Sensor):
         Receive and process packets from all other sensors in the network.
         """
 
-        if not self.check_receive(packet):
+        if not self._check_receive(packet):
             if self._id > 0:
                 self._next_timestamp = self._scheduler.synchronize(packet)
 
                 # Create and complete the packet for the ground station.
-                ground_station_packet = self.make_rssi_ground_station_packet(packet)
+                ground_station_packet = self._make_rssi_ground_station_packet(packet)
                 ground_station_packet.set("rssi", random.randint(0, 60))
                 frame_id = chr(random.randint(1, 255))
                 self._data[frame_id] = ground_station_packet

--- a/zigbee/XBee_Sensor_Simulator.py
+++ b/zigbee/XBee_Sensor_Simulator.py
@@ -127,15 +127,6 @@ class XBee_Sensor_Simulator(XBee_Sensor):
             self._send_tx_frame(packet, 0)
             self._data.pop(frame_id)
 
-    def _send_custom_packets(self):
-        """
-        Send custom packets to their destinations.
-        """
-
-        while not self._queue.empty():
-            item = self._queue.get()
-            self._send_tx_frame(item["packet"], item["to"])
-
     def _send_tx_frame(self, packet, to=None):
         """
         Send a TX frame to another sensor.


### PR DESCRIPTION
Move more code to the `XBee_Sensor` base class and only send custom packets when we are not sending signal strength measurement packets.
