### PR TITLE
Thread interrupt cleanup

### DIFF
--- a/core/Thread_Manager.py
+++ b/core/Thread_Manager.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import thread
 
 class Thread_Manager(object):
     def __init__(self):
@@ -34,6 +35,21 @@ class Thread_Manager(object):
         self.log("main thread")
         for name, thread in self._threads.items():
             thread.deactivate()
+
+    def interrupt(self, name):
+        """
+        Handle an exception on a registered thread.
+
+        This method interrupts the main thread and logs the exception.
+        """
+
+        self.log("'{}' thread".format(name))
+
+        # Do not interrupt the main thread if the thread is not registered.
+        # This prevents stale threads that have long been deactivated and 
+        # unregistered from causing interrupts or segmentation faults.
+        if name in self._threads:
+            thread.interrupt_main()
 
     def log(self, source):
         """

--- a/core/Thread_Manager.py
+++ b/core/Thread_Manager.py
@@ -11,16 +11,19 @@ class Thread_Manager(object):
 
         self._threads = {}
 
-    def register(self, name, thread):
+    def register(self, name, threadable):
         """
-        Register a thread.
+        Register a `Threadable` object by its `name`.
         """
 
-        self._threads[name] = thread
+        self._threads[name] = threadable
 
     def unregister(self, name):
         """
-        Unregister a thread.
+        Unregister a thread given its `name`.
+
+        A `name` for a `Threadable` object that is currently not registered is
+        ignored.
         """
 
         if name not in self._threads:
@@ -38,8 +41,8 @@ class Thread_Manager(object):
         if sys.exc_info() != (None, None, None):
             self.log("main thread")
 
-        for name, thread in self._threads.items():
-            thread.deactivate()
+        for name, threadable in self._threads.items():
+            threadable.deactivate()
 
     def interrupt(self, name):
         """

--- a/core/Thread_Manager.py
+++ b/core/Thread_Manager.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import sys
 import thread
 
 class Thread_Manager(object):
@@ -32,7 +33,11 @@ class Thread_Manager(object):
         Destroy all registered threads by deactivating them.
         """
 
-        self.log("main thread")
+        # Log the destroy call only if it is being called from an except clause
+        # to prevent "None" spam in the logs.
+        if sys.exc_info() != (None, None, None):
+            self.log("main thread")
+
         for name, thread in self._threads.items():
             thread.deactivate()
 

--- a/core/Threadable.py
+++ b/core/Threadable.py
@@ -25,4 +25,5 @@ class Threadable(object):
         """
         Interrupt the main thread.
         """
+
         self._thread_manager.interrupt(self._name)

--- a/core/Threadable.py
+++ b/core/Threadable.py
@@ -1,5 +1,3 @@
-import thread
-
 class Threadable(object):
     def __init__(self, name, thread_manager):
         """
@@ -27,6 +25,4 @@ class Threadable(object):
         """
         Interrupt the main thread.
         """
-
-        self._thread_manager.log("'{}' thread".format(self._name))
-        thread.interrupt_main()
+        self._thread_manager.interrupt(self._name)

--- a/test.py
+++ b/test.py
@@ -47,11 +47,14 @@ class Test_Run(object):
 
     def clear_logs_directory(self):
         """
-        Clear the logs directory.
+        Print all logs and clear the logs directory.
         """
 
         files = glob.glob("logs/*.log")
         for file in files:
+            with open(file) as f:
+                print(f.read())
+
             os.remove(file)
 
 def main():

--- a/tests/core_thread_manager.py
+++ b/tests/core_thread_manager.py
@@ -1,5 +1,7 @@
+import logging
+import thread
 import unittest
-from mock import patch
+from mock import patch, call, Mock, MagicMock
 from ..core.Threadable import Threadable
 from ..core.Thread_Manager import Thread_Manager
 
@@ -71,3 +73,41 @@ class TestCoreThreadManager(ThreadableTestCase):
         self.thread_manager.register("mock_thread", mock_thread)
         self.thread_manager.destroy()
         self.assertTrue(mock_thread_deactivate.called)
+
+    @patch.object(thread, 'interrupt_main')
+    @patch.object(Thread_Manager, 'log')
+    def test_interrupt_unregistered(self, log_mock, interrupt_mock):
+        # An unregistered thread has its error logged, but does not interrupt 
+        # the main thread.
+        mock_thread = Mock_Thread(self.thread_manager)
+        mock_thread.interrupt()
+        log_mock.assert_called_once_with("'mock_thread' thread")
+        self.assertEqual(interrupt_mock.call_count, 0)
+
+    @patch.object(thread, 'interrupt_main')
+    @patch.object(Thread_Manager, 'log')
+    def test_interrupt_registered(self, log_mock, interrupt_mock):
+        # An registered thread has its error logged and interrupts the main 
+        # thread.
+        mock_thread = Mock_Thread(self.thread_manager)
+        self.thread_manager.register("mock_thread", mock_thread)
+        mock_thread.interrupt()
+        log_mock.assert_called_once_with("'mock_thread' thread")
+        self.assertEqual(interrupt_mock.call_count, 1)
+
+    def test_log(self):
+        # Test lazy initialization of logger.
+        logger_mock = MagicMock()
+        patcher = patch.object(logging, 'getLogger', Mock(return_value=logger_mock))
+        patcher.start()
+        self.thread_manager.log("'foo' source")
+        self.assertEqual(self.thread_manager._logger, logger_mock)
+        logger_mock.setLevel.assert_called_once_with(logging.DEBUG)
+        self.assertEqual(logger_mock.addHandler.call_count, 1)
+
+        # Test that all calls are logged.
+        self.thread_manager.log("'bar' source")
+        self.assertEqual(logger_mock.exception.call_count, 2)
+        logger_mock.exception.assert_has_calls([call("'foo' source"), call("'bar' source")])
+
+        patcher.stop()

--- a/tests/core_thread_manager.py
+++ b/tests/core_thread_manager.py
@@ -76,11 +76,11 @@ class TestCoreThreadManager(ThreadableTestCase):
 
     @patch.object(Thread_Manager, 'log')
     def test_destroy_log(self, log_mock):
-        # The destroy does not call log outside an exception context.
+        # The `destroy` method does not call `log` outside an exception context.
         self.thread_manager.destroy()
         self.assertEqual(log_mock.call_count, 0)
 
-        # When destroy is in an exception handling block, log is called.
+        # If `destroy` is called in an exception handling block, `log` is called.
         try:
             raise RuntimeError("Exception must be handled in this test")
         except:
@@ -101,8 +101,7 @@ class TestCoreThreadManager(ThreadableTestCase):
     @patch.object(thread, 'interrupt_main')
     @patch.object(Thread_Manager, 'log')
     def test_interrupt_registered(self, log_mock, interrupt_mock):
-        # An registered thread has its error logged and interrupts the main 
-        # thread.
+        # A registered thread has its error logged and interrupts the main thread.
         mock_thread = Mock_Thread(self.thread_manager)
         self.thread_manager.register("mock_thread", mock_thread)
         mock_thread.interrupt()

--- a/tests/core_thread_manager.py
+++ b/tests/core_thread_manager.py
@@ -74,6 +74,20 @@ class TestCoreThreadManager(ThreadableTestCase):
         self.thread_manager.destroy()
         self.assertTrue(mock_thread_deactivate.called)
 
+    @patch.object(Thread_Manager, 'log')
+    def test_destroy_log(self, log_mock):
+        # The destroy does not call log outside an exception context.
+        self.thread_manager.destroy()
+        self.assertEqual(log_mock.call_count, 0)
+
+        # When destroy is in an exception handling block, log is called.
+        try:
+            raise RuntimeError("Exception must be handled in this test")
+        except:
+            self.thread_manager.destroy()
+
+        log_mock.assert_called_once_with("main thread")
+
     @patch.object(thread, 'interrupt_main')
     @patch.object(Thread_Manager, 'log')
     def test_interrupt_unregistered(self, log_mock, interrupt_mock):

--- a/tests/core_thread_manager.py
+++ b/tests/core_thread_manager.py
@@ -114,6 +114,7 @@ class TestCoreThreadManager(ThreadableTestCase):
         logger_mock = MagicMock()
         patcher = patch.object(logging, 'getLogger', Mock(return_value=logger_mock))
         patcher.start()
+        self.assertFalse(hasattr(self.thread_manager, "_logger"))
         self.thread_manager.log("'foo' source")
         self.assertEqual(self.thread_manager._logger, logger_mock)
         logger_mock.setLevel.assert_called_once_with(logging.DEBUG)

--- a/tests/mission_cycle.py
+++ b/tests/mission_cycle.py
@@ -81,7 +81,7 @@ class TestMissionCycle(ThreadableTestCase, USBManagerTestCase, LocationTestCase,
         self.assertEqual(self.vehicle._waypoints, [(1,0)])
         self.assertEqual(self.vehicle._state.name, "move")
         self.assertEqual(self.vehicle.get_waypoint(), LocationLocal(1,0,0))
-        self.assertNotEqual(self.master.readline(), "")
+        self.assertNotEqual(self._ttl_device.readline(), "")
 
         self.vehicle._location = (1,0)
         self.vehicle._state = Robot_State("intersection")

--- a/tests/mission_cycle.py
+++ b/tests/mission_cycle.py
@@ -2,6 +2,7 @@ import itertools
 from mock import patch
 from dronekit import LocationLocal
 from ..environment.Environment import Environment
+from ..location.Line_Follower import Line_Follower
 from ..trajectory.Mission import Mission_Cycle
 from ..vehicle.Robot_Vehicle import Robot_State
 from ..settings import Arguments
@@ -63,7 +64,8 @@ class TestMissionCycle(ThreadableTestCase, USBManagerTestCase, LocationTestCase,
             (0,2), (0,2), (0,2), (0,2)
         ])
 
-    def test_step(self):
+    @patch.object(Line_Follower, "_loop")
+    def test_step(self, line_follower_arduino_read_mock):
         with patch('sys.stdout'):
             self.mission.setup()
             self.mission.arm_and_takeoff()

--- a/tests/xbee_configurator.py
+++ b/tests/xbee_configurator.py
@@ -11,7 +11,7 @@ class TestXBeeConfigurator(USBManagerTestCase, SettingsTestCase):
     def setUp(self):
         super(TestXBeeConfigurator, self).setUp()
 
-        self.arguments = Arguments("settings.json", ["--port={}".format(self.port)])
+        self.arguments = Arguments("settings.json", ["--port", self._xbee_port])
         self.settings = self.arguments.get_settings("xbee_configurator")
 
         self.usb_manager.index()
@@ -19,7 +19,7 @@ class TestXBeeConfigurator(USBManagerTestCase, SettingsTestCase):
 
     def test_initialization(self):
         self.assertIsInstance(self.configurator._serial_connection, serial.Serial)
-        self.assertEqual(self.configurator._serial_connection.port, self.port)
+        self.assertEqual(self.configurator._serial_connection.port, self._xbee_port)
         self.assertEqual(self.configurator._serial_connection.baudrate,
                          USB_Device_Baud_Rate.XBEE)
         self.assertIsInstance(self.configurator._sensor, ZigBee)

--- a/tests/xbee_sensor_physical.py
+++ b/tests/xbee_sensor_physical.py
@@ -32,7 +32,7 @@ class TestXBeeSensorPhysical(USBManagerTestCase, ThreadableTestCase, SettingsTes
         self.sensor_id = 1
 
         self.arguments = Arguments("settings.json", [
-            "--port", self.port,
+            "--port", self._xbee_port,
             "--sensors", "sensor_0", "sensor_1", "sensor_2", "sensor_3",
             "sensor_4", "sensor_5", "sensor_6", "sensor_7", "sensor_8"
         ])


### PR DESCRIPTION
- Do not interrupt the main thread from unregistered threads. This should stop tests from failing when they actually succeed, but have threads running that have not yet detected that they are already deactivated.
- Clean up "None" spam in logs when a script finished normally.
- Display logs in the test runner before clearing them.

This should close #75 but we should probably make sure that all intermittent failures are now gone. @timvandermeij can you still reproduce the mission_cycle test failure mentioned in that bug?
