### PR TITLE
XBee settings sender/receiver

### DIFF
--- a/control_panel/Control_Panel_Controller.py
+++ b/control_panel/Control_Panel_Controller.py
@@ -53,7 +53,7 @@ class Control_Panel_Controller(object):
             Control_Panel_View_Name.LOADING: "control_panel_loading",
             Control_Panel_View_Name.RECONSTRUCTION: "control_panel_reconstruction",
             Control_Panel_View_Name.WAYPOINTS: "control_panel_waypoints",
-            Control_Panel_View_Name.SETTINGS: "control_panel"
+            Control_Panel_View_Name.SETTINGS: "control_panel_settings"
         }
         self._view_data = dict([(name, {}) for name in self._view_components.iterkeys()])
         self.load_settings()

--- a/control_panel/Control_Panel_Settings_View.py
+++ b/control_panel/Control_Panel_Settings_View.py
@@ -155,7 +155,6 @@ class Control_Panel_Settings_View(Control_Panel_View):
         sender.start()
 
     def _make_add_setting_packet(self, vehicle, index, key):
-        print(vehicle, index, key, self._new_settings[key])
         packet = XBee_Packet()
         packet.set("specification", "setting_add")
         packet.set("index", index)

--- a/control_panel/Control_Panel_Settings_View.py
+++ b/control_panel/Control_Panel_Settings_View.py
@@ -2,7 +2,9 @@ import json
 from PyQt4 import QtGui
 from Control_Panel_View import Control_Panel_View
 from Control_Panel_Widgets import QLineEditClear, SettingsWidget
+from Control_Panel_XBee_Sender import Control_Panel_XBee_Sender
 from ..settings import Settings
+from ..zigbee.XBee_Packet import XBee_Packet
 
 class Setting_Filter_Match(object):
     NONE = 0
@@ -119,14 +121,57 @@ class Control_Panel_Settings_View(Control_Panel_View):
         dialog.setLayout(dialogLayout)
 
         result = dialog.exec_()
-        if result == QtGui.QDialog.Accepted:
-            if groundCheckBox.isChecked():
-                with open('settings.json', 'w') as f:
-                    f.write(pretty_json)
+        if result != QtGui.QDialog.Accepted:
+            return
 
-                Settings.settings_files = {}
-                self._controller.arguments.groups = {}
-                self._controller.load_settings()
+        self._new_settings = flat_settings
+
+        vehicle_settings = {}
+        keys = sorted(self._new_settings.keys())
+        count = 0
+        for vehicle in xrange(1, self._controller.xbee.number_of_sensors + 1):
+            if vehicleCheckBoxes[vehicle].isChecked():
+                vehicle_settings[vehicle] = keys
+                count += len(keys)
+
+        if not vehicle_settings:
+            if groundCheckBox.isChecked():
+                self._set_ground_station_settings()
+
+            return
+
+        max_retries = self._settings.get("settings_max_retries")
+        retry_interval = self._settings.get("settings_retry_interval")
+        sender = Control_Panel_XBee_Sender(self._controller, "setting",
+                                           vehicle_settings, count,
+                                           "setting_clear",
+                                           self._make_add_setting_packet,
+                                           "setting_done", "setting_ack",
+                                           max_retries, retry_interval)
+
+        if groundCheckBox.isChecked():
+            sender.connect_accepted(self._set_ground_station_settings)
+
+        sender.start()
+
+    def _make_add_setting_packet(self, vehicle, index, key):
+        print(vehicle, index, key, self._new_settings[key])
+        packet = XBee_Packet()
+        packet.set("specification", "setting_add")
+        packet.set("index", index)
+        packet.set("key", str(key))
+        packet.set("value", self._new_settings[key])
+        packet.set("to_id", vehicle)
+
+        return packet
+
+    def _set_ground_station_settings(self):
+        with open(self._controller.arguments.settings_file, 'w') as json_file:
+            json.dump(self._new_settings, json_file, indent=4, sort_keys=True)
+
+        Settings.settings_files = {}
+        self._controller.arguments.groups = {}
+        self._controller.load_settings()
 
     def _scroll_to_match(self):
         self._listWidget.scrollToItem(self._listWidget.currentItem())

--- a/control_panel/Control_Panel_Settings_View.py
+++ b/control_panel/Control_Panel_Settings_View.py
@@ -129,6 +129,8 @@ class Control_Panel_Settings_View(Control_Panel_View):
                 self._controller.load_settings()
 
     def _scroll_to_match(self):
+        self._listWidget.scrollToItem(self._listWidget.currentItem())
+
         index = self._listWidget.currentRow()
         if index in self._best_matches:
             key = self._best_matches[index]

--- a/control_panel/Control_Panel_Settings_View.py
+++ b/control_panel/Control_Panel_Settings_View.py
@@ -140,14 +140,17 @@ class Control_Panel_Settings_View(Control_Panel_View):
 
             return
 
-        max_retries = self._settings.get("settings_max_retries")
-        retry_interval = self._settings.get("settings_retry_interval")
-        sender = Control_Panel_XBee_Sender(self._controller, "setting",
-                                           vehicle_settings, count,
-                                           "setting_clear",
-                                           self._make_add_setting_packet,
-                                           "setting_done", "setting_ack",
-                                           max_retries, retry_interval)
+        configuration = {
+            "name": "setting",
+            "clear_message": "setting_clear",
+            "add_callback": self._make_add_setting_packet,
+            "done_message": "setting_done",
+            "ack_message": "setting_ack",
+            "max_retries": self._settings.get("settings_max_retries"),
+            "retry_interval": self._settings.get("settings_retry_interval")
+        }
+        sender = Control_Panel_XBee_Sender(self._controller, vehicle_settings,
+                                           count, configuration)
 
         if groundCheckBox.isChecked():
             sender.connect_accepted(self._set_ground_station_settings)

--- a/control_panel/Control_Panel_Waypoints_View.py
+++ b/control_panel/Control_Panel_Waypoints_View.py
@@ -3,6 +3,7 @@ import os
 from functools import partial
 from PyQt4 import QtCore, QtGui
 from Control_Panel_View import Control_Panel_View
+from Control_Panel_XBee_Sender import Control_Panel_XBee_Sender
 from ..zigbee.XBee_Packet import XBee_Packet
 
 class Control_Panel_Waypoints_View(Control_Panel_View):
@@ -11,12 +12,6 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
 
         self._max_retries = self._settings.get("waypoints_max_retries")
         self._retry_interval = self._settings.get("waypoints_retry_interval")
-        self._clear_send()
-
-    def clear(self, layout=None):
-        super(Control_Panel_Waypoints_View, self).clear(layout)
-
-        self._controller.remove_packet_callback("waypoint_ack")
 
     def load(self, data):
         self._listWidget = QtGui.QListWidget()
@@ -65,7 +60,6 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
         """
 
         self._add_menu_bar()
-        self._controller.add_packet_callback("waypoint_ack", self._receive_ack)
 
         self._listWidget.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Expanding)
         self._listWidget.setCurrentRow(0)
@@ -257,62 +251,15 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
                                        "There are no vehicles with waypoints.")
             return
 
-        # Create a progress dialog and send the waypoints to the vehicles.
-        self._progress = QtGui.QProgressDialog(self._controller.central_widget)
-        self._progress.setMinimum(0)
-        self._progress.setMaximum(total)
-        self._progress.setWindowModality(QtCore.Qt.WindowModal)
-        self._progress.setMinimumDuration(0)
-        self._progress.setCancelButtonText("Cancel")
-        self._progress.canceled.connect(lambda: self._cancel())
-        self._progress.setWindowTitle("Sending waypoints")
-        self._progress.setLabelText("Initializing...")
-        self._progress.open()
+        sender = Control_Panel_XBee_Sender(self._controller, "waypoint",
+                                           waypoints, total, "waypoint_clear",
+                                           self._make_add_waypoint_packet, 
+                                           "waypoint_done", "waypoint_ack",
+                                           self._max_retries,
+                                           self._retry_interval)
+        sender.start()
 
-        self._labels = dict([(vehicle, "") for vehicle in waypoints])
-
-        self._retry_counts = dict([(vehicle, self._max_retries) for vehicle in waypoints])
-        self._indexes = dict([(vehicle, -1) for vehicle in waypoints])
-
-        self._timers = {}
-        for vehicle in waypoints:
-            timer = QtCore.QTimer()
-            timer.setInterval(self._retry_interval * 1000)
-            timer.setSingleShot(True)
-            # Bind timeout signal to retry for the current vehicle.
-            timer.timeout.connect(partial(self._retry, vehicle))
-            self._timers[vehicle] = timer
-
-        self._waypoints = waypoints
-        self._total = total
-        for vehicle in self._waypoints:
-            self._send_clear(vehicle)
-
-    def _send_clear(self, vehicle):
-        packet = XBee_Packet()
-        packet.set("specification", "waypoint_clear")
-        packet.set("to_id", vehicle)
-
-        self._controller.xbee.enqueue(packet, to=vehicle)
-
-        self._set_label(vehicle, "Clearing old waypoints")
-        self._timers[vehicle].start()
-
-    def _send_one(self, vehicle):
-        index = self._indexes[vehicle]
-        if len(self._waypoints[vehicle]) <= index:
-            # Enqueue a packet indicating that waypoint sending
-            # for this vehicle is done.
-            packet = XBee_Packet()
-            packet.set("specification", "waypoint_done")
-            packet.set("to_id", vehicle)
-            self._controller.xbee.enqueue(packet, to=vehicle)
-
-            self._update_value()
-            return
-
-        waypoint = self._waypoints[vehicle][index]
-
+    def _make_add_waypoint_packet(self, vehicle, index, waypoint):
         packet = XBee_Packet()
         packet.set("specification", "waypoint_add")
         packet.set("latitude", waypoint[0])
@@ -320,72 +267,4 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
         packet.set("index", index)
         packet.set("to_id", vehicle)
 
-        self._controller.xbee.enqueue(packet, to=vehicle)
-
-        self._set_label(vehicle, "Sending waypoint #{} ({}, {})".format(index, waypoint[0], waypoint[1]))
-        self._timers[vehicle].start()
-
-    def _receive_ack(self, packet):
-        vehicle = packet.get("sensor_id")
-        index = packet.get("next_index")
-
-        if vehicle not in self._timers:
-            return
-
-        self._indexes[vehicle] = index
-        self._retry_counts[vehicle] = self._max_retries + 1
-
-    def _retry(self, vehicle):
-        self._retry_counts[vehicle] -= 1
-        if self._retry_counts[vehicle] > 0:
-            if self._indexes[vehicle] == -1:
-                self._send_clear(vehicle)
-            else:
-                self._send_one(vehicle)
-        else:
-            self._cancel("Vehicle {}: Maximum retry attempts for {} reached".format(vehicle, "clearing waypoints" if self._indexes[vehicle] == -1 else "index {}".format(self._indexes[vehicle])))
-
-    def _set_label(self, vehicle, text):
-        self._labels[vehicle] = text
-        self._update_labels()
-        self._update_value()
-
-    def _update_labels(self):
-        labels = []
-        for vehicle in sorted(self._labels.iterkeys()):
-            label = self._labels[vehicle]
-            if self._retry_counts[vehicle] < self._max_retries:
-                retry = " ({} attempts remaining)".format(self._retry_counts[vehicle])
-            else:
-                retry = ""
-
-            labels.append("Vehicle {}: {}{}".format(vehicle, label, retry))
-
-        self._progress.setLabelText("\n".join(labels))
-
-    def _update_value(self):
-        self._progress.setValue(max(0, min(self._total, sum(self._indexes.values()))))
-
-    def _cancel(self, message=None):
-        for timer in self._timers.values():
-            timer.stop()
-
-        if self._progress is not None:
-            self._progress.cancel()
-            self._progress.deleteLater()
-
-        if message is not None:
-            QtGui.QMessageBox.critical(self._controller.central_widget,
-                                       "Sending failed", message)
-
-        self._clear_send()
-
-    def _clear_send(self):
-        # Clear variables used in the _send method and its submethods
-        self._progress = None
-        self._labels = {}
-        self._retry_counts = {}
-        self._indexes = {}
-        self._waypoints = {}
-        self._total = 0
-        self._timers = {}
+        return packet

--- a/control_panel/Control_Panel_Waypoints_View.py
+++ b/control_panel/Control_Panel_Waypoints_View.py
@@ -251,12 +251,17 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
                                        "There are no vehicles with waypoints.")
             return
 
-        sender = Control_Panel_XBee_Sender(self._controller, "waypoint",
-                                           waypoints, total, "waypoint_clear",
-                                           self._make_add_waypoint_packet, 
-                                           "waypoint_done", "waypoint_ack",
-                                           self._max_retries,
-                                           self._retry_interval)
+        configuration = {
+            "name": "waypoint",
+            "clear_message": "waypoint_clear",
+            "add_callback": self._make_add_waypoint_packet,
+            "done_message": "waypoint_done",
+            "ack_message": "waypoint_ack",
+            "max_retries": self._max_retries,
+            "retry_interval": self._retry_interval
+        }
+        sender = Control_Panel_XBee_Sender(self._controller, waypoints, total,
+                                           configuration)
         sender.start()
 
     def _make_add_waypoint_packet(self, vehicle, index, waypoint):

--- a/control_panel/Control_Panel_Widgets.py
+++ b/control_panel/Control_Panel_Widgets.py
@@ -96,6 +96,9 @@ class SettingsWidget(QtGui.QWidget):
 
         if self._settings.parent is not None:
             parentButton = QtGui.QCommandLinkButton(self._settings.parent.name, "Go to parent ({})".format(self._settings.parent.component_name))
+            policy = parentButton.sizePolicy()
+            policy.setVerticalPolicy(QtGui.QSizePolicy.Fixed)
+            parentButton.setSizePolicy(policy)
             parentButton.clicked.connect(self._trigger_parent_clicked)
 
             layout.addWidget(parentButton)
@@ -119,7 +122,7 @@ class SettingsWidget(QtGui.QWidget):
             descriptionLabel = QtGui.QLabel("Description:")
             descriptionLabel.setAlignment(QtCore.Qt.AlignTop)
             description = QtGui.QLabel(self._arguments.get_help(key, info))
-            description.setSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding)
+            description.setSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Fixed)
             description.setWordWrap(True)
             formLayout.addRow(descriptionLabel, description)
 
@@ -129,6 +132,11 @@ class SettingsWidget(QtGui.QWidget):
             formLayout.addRow(valueLabel, valueWidget)
 
             groupBox = QtGui.QGroupBox(key)
+
+            groupBox.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)
+            for action in valueWidget.get_actions():
+                groupBox.addAction(action)
+
             groupBox.setLayout(formLayout)
             layout.addWidget(groupBox)
 
@@ -177,16 +185,32 @@ class FormWidget(QtGui.QWidget):
         self.form = form
         self.key = key
         self.info = info
+
+        reset_action = QtGui.QAction("Reset to current value", self)
+        reset_action.triggered.connect(self.reset_value)
+        default_action = QtGui.QAction("Reset to default value", self)
+        default_action.triggered.connect(self.set_default_value)
+        self._actions = [reset_action, default_action]
+
         self.setup_form()
 
     def setup_form(self):
         pass
 
+    def get_actions(self):
+        return self._actions
+
     def get_value(self):
         raise NotImplementedError("Subclasses must implement `get_value`")
 
+    def set_value(self, value):
+        raise NotImplementedError("Subclasses must implement `set_value(value)`")
+
     def reset_value(self):
-        raise NotImplementedError("Subclasses must implement `reset_value`")
+        self.set_value(self.info["value"])
+
+    def set_default_value(self):
+        self.set_value(self.info["default"])
 
     def is_value_changed(self):
         return self.get_value() != self.info["value"]
@@ -215,9 +239,9 @@ class BooleanFormWidget(FormWidget):
     def get_value(self):
         return self._enabledButton.isChecked()
 
-    def reset_value(self):
-        self._enabledButton.setChecked(self.info["value"])
-        self._disabledButton.setChecked(not self.info["value"])
+    def set_value(self, value):
+        self._enabledButton.setChecked(value)
+        self._disabledButton.setChecked(not value)
 
 class TextFormWidget(QtGui.QLineEdit, FormWidget):
     def __init__(self, form, key, info, *a, **kw):
@@ -231,6 +255,16 @@ class TextFormWidget(QtGui.QLineEdit, FormWidget):
         QtGui.QLineEdit.__init__(self, *a, **kw)
         FormWidget.__init__(self, form, key, info, *a, **kw)
         self._background_color = ""
+
+    def contextMenuEvent(self, event):
+        menu = self.createStandardContextMenu()
+        menu.addSeparator()
+        for action in self._actions:
+            menu.addAction(action)
+
+        menu.setStyleSheet("background-color: base")
+        menu.exec_(event.globalPos())
+        menu.clear()
 
     def setup_form(self):
         self.reset_value()
@@ -254,8 +288,8 @@ class TextFormWidget(QtGui.QLineEdit, FormWidget):
 
         return str(text)
 
-    def reset_value(self):
-        self.setText(self.format_value(self.info["value"]))
+    def set_value(self, value):
+        self.setText(self.format_value(value))
 
     def _format(self):
         self.setText(self.format_value(self.text()))
@@ -418,6 +452,7 @@ class NumericFormWidget(TextFormWidget):
 class NumericSliderFormWidget(FormWidget):
     def setup_form(self):
         self._valueWidget = NumericFormWidget(self.form, "{}-num".format(self.key), self.info)
+        self._slider = None
 
         self._layout = QtGui.QHBoxLayout()
         self._layout.setContentsMargins(0, 0, 0, 0)
@@ -448,6 +483,11 @@ class NumericSliderFormWidget(FormWidget):
 
     def get_value(self):
         return self._valueWidget.get_value()
+
+    def set_value(self, value):
+        self._valueWidget.set_value(value)
+        if self._slider is not None:
+            self._update_slider(self._valueWidget.text())
 
     def _slider_to_value(self, value):
         minimum = self._slider.minimum()
@@ -599,6 +639,22 @@ class ListFormWidget(FormWidget):
     def get_value(self):
         return [sub_widget.get_value() for sub_widget in self._sub_widgets]
 
+    def set_value(self, value):
+        # Replace values in item widgets, add widgets to the list if necessary.
+        for position, sub_value in enumerate(value):
+            if position >= len(self._sub_widgets):
+                self._add_to_list()
+
+            self._sub_widgets[position].set_value(sub_value)
+
+        # Remove item widgets not having a value anymore.
+        for index in xrange(len(value), len(self._sub_widgets)):
+            item = self._layout.itemAt(len(value))
+            if item.layout():
+                self._remove_item(item, item.itemAt(0).widget(), item.itemAt(1).widget())
+            else:
+                self._layout.removeItem(item)
+
 class DictFormWidget(FormWidget):
     def setup_form(self):
         self._sub_widgets = {}
@@ -623,7 +679,11 @@ class DictFormWidget(FormWidget):
         self.setLayout(formLayout)
 
     def get_value(self):
-        return dict((key, subWidget.get_value()) for (key, subWidget) in self._sub_widgets.iteritems())
+        return dict((key, subWidget.get_value()) for key, subWidget in self._sub_widgets.iteritems())
+
+    def set_value(self, value):
+        for key, subWidget in self._sub_widgets.iteritems():
+            subWidget.set_value(value[key])
 
 class ChoicesFormWidget(QtGui.QComboBox, FormWidget):
     def __init__(self, form, key, info, *a, **kw):
@@ -645,6 +705,14 @@ class ChoicesFormWidget(QtGui.QComboBox, FormWidget):
             if choice == self.info["value"]:
                 self.setCurrentIndex(i)
 
+    def contextMenuEvent(self, event):
+        menu = QtGui.QMenu(self)
+        for action in self._actions:
+            menu.addAction(action)
+
+        menu.exec_(event.globalPos())
+        menu.clear()
+
     def get_value(self):
         if self.info["type"] in self._types:
             type_cast = self._types[self.info["type"]]
@@ -652,3 +720,7 @@ class ChoicesFormWidget(QtGui.QComboBox, FormWidget):
             type_cast = str
 
         return type_cast(self.currentText())
+
+    def set_value(self, value):
+        index = self.findText(str(value))
+        self.setCurrentIndex(index)

--- a/control_panel/Control_Panel_XBee_Sender.py
+++ b/control_panel/Control_Panel_XBee_Sender.py
@@ -87,7 +87,7 @@ class Control_Panel_XBee_Sender(object):
 
         self._controller.xbee.enqueue(packet, to=vehicle)
 
-        self._set_label(vehicle, "Sending {} #{}: {}".format(self._name, index, data))
+        self._set_label(vehicle, "Sending {} #{}: {}".format(self._name, index+1, data))
         self._timers[vehicle].start()
 
     def _receive_ack(self, packet):

--- a/control_panel/Control_Panel_XBee_Sender.py
+++ b/control_panel/Control_Panel_XBee_Sender.py
@@ -1,0 +1,146 @@
+from functools import partial
+from PyQt4 import QtGui, QtCore
+from ..zigbee.XBee_Packet import XBee_Packet
+
+class Control_Panel_XBee_Sender(object):
+    """
+    Handler for sending status changes to the XBee devices on the vehicles.
+    """
+
+    def __init__(self, controller, name, data, total, clear_message,
+                 add_callback, done_message, ack_message, max_retries,
+                 retry_interval):
+        self._controller = controller
+        self._name = name
+
+        self._clear_message = clear_message
+        self._add_callback = add_callback
+        self._done_message = done_message
+        self._ack_message = ack_message
+
+        self._max_retries = max_retries
+        self._retry_interval = retry_interval
+
+        self._labels = dict([(vehicle, "") for vehicle in data])
+
+        self._retry_counts = dict([(vehicle, self._max_retries) for vehicle in data])
+        self._indexes = dict([(vehicle, -1) for vehicle in data])
+
+        self._timers = {}
+
+        self._data = data
+        self._total = total
+
+    def start(self):
+        self._controller.add_packet_callback(self._ack_message,
+                                             self._receive_ack)
+
+        # Create a progress dialog and send the data to the vehicles.
+        self._progress = QtGui.QProgressDialog(self._controller.central_widget)
+        self._progress.setMinimum(0)
+        self._progress.setMaximum(self._total)
+        self._progress.setWindowModality(QtCore.Qt.WindowModal)
+        self._progress.setMinimumDuration(0)
+        self._progress.setCancelButtonText("Cancel")
+        self._progress.canceled.connect(lambda: self._cancel())
+        self._progress.setWindowTitle("Sending {}s".format(self._name))
+        self._progress.setLabelText("Initializing...")
+        self._progress.open()
+
+        for vehicle in self._data:
+            timer = QtCore.QTimer()
+            timer.setInterval(self._retry_interval * 1000)
+            timer.setSingleShot(True)
+            # Bind timeout signal to retry for the current vehicle.
+            timer.timeout.connect(partial(self._retry, vehicle))
+            self._timers[vehicle] = timer
+
+        for vehicle in self._data:
+            self._send_clear(vehicle)
+
+    def _send_clear(self, vehicle):
+        packet = XBee_Packet()
+        packet.set("specification", self._clear_message)
+        packet.set("to_id", vehicle)
+
+        self._controller.xbee.enqueue(packet, to=vehicle)
+
+        self._set_label(vehicle, "Clearing old {}s".format(self._name))
+        self._timers[vehicle].start()
+
+    def _send_one(self, vehicle):
+        index = self._indexes[vehicle]
+        if len(self._data[vehicle]) <= index:
+            # Enqueue a packet indicating that sending data to this vehicle is 
+            # done.
+            packet = XBee_Packet()
+            packet.set("specification", self._done_message)
+            packet.set("to_id", vehicle)
+            self._controller.xbee.enqueue(packet, to=vehicle)
+
+            self._update_value()
+            return
+
+        data = self._data[vehicle][index]
+
+        packet = self._add_callback(vehicle, index, data)
+
+        self._controller.xbee.enqueue(packet, to=vehicle)
+
+        self._set_label(vehicle, "Sending {} #{}: {}".format(self._name, index, data))
+        self._timers[vehicle].start()
+
+    def _receive_ack(self, packet):
+        vehicle = packet.get("sensor_id")
+        index = packet.get("next_index")
+
+        if vehicle not in self._timers:
+            return
+
+        self._indexes[vehicle] = index
+        self._retry_counts[vehicle] = self._max_retries + 1
+
+    def _retry(self, vehicle):
+        self._retry_counts[vehicle] -= 1
+        if self._retry_counts[vehicle] > 0:
+            if self._indexes[vehicle] == -1:
+                self._send_clear(vehicle)
+            else:
+                self._send_one(vehicle)
+        else:
+            self._cancel("Vehicle {}: Maximum retry attempts for {} reached".format(vehicle, "clearing {}s".format(self._name) if self._indexes[vehicle] == -1 else "{} #{}".format(self._name, self._indexes[vehicle])))
+
+    def _set_label(self, vehicle, text):
+        self._labels[vehicle] = text
+        self._update_labels()
+        self._update_value()
+
+    def _update_labels(self):
+        labels = []
+        for vehicle in sorted(self._labels.iterkeys()):
+            label = self._labels[vehicle]
+            if self._retry_counts[vehicle] < self._max_retries:
+                retry = " ({} attempts remaining)".format(self._retry_counts[vehicle])
+            else:
+                retry = ""
+
+            labels.append("Vehicle {}: {}{}".format(vehicle, label, retry))
+
+        self._progress.setLabelText("\n".join(labels))
+
+    def _update_value(self):
+        self._progress.setValue(max(0, min(self._total, sum(self._indexes.values()))))
+
+    def _cancel(self, message=None):
+        self._controller.remove_packet_callback(self._ack_message)
+
+        for timer in self._timers.values():
+            timer.stop()
+
+        if self._progress is not None:
+            self._progress.cancel()
+            self._progress.deleteLater()
+
+        if message is not None:
+            QtGui.QMessageBox.critical(self._controller.central_widget,
+                                       "Sending failed", message)

--- a/control_panel/Control_Panel_XBee_Sender.py
+++ b/control_panel/Control_Panel_XBee_Sender.py
@@ -31,11 +31,6 @@ class Control_Panel_XBee_Sender(object):
         self._data = data
         self._total = total
 
-    def start(self):
-        self._controller.add_packet_callback(self._ack_message,
-                                             self._receive_ack)
-
-        # Create a progress dialog and send the data to the vehicles.
         self._progress = QtGui.QProgressDialog(self._controller.central_widget)
         self._progress.setMinimum(0)
         self._progress.setMaximum(self._total)
@@ -45,6 +40,15 @@ class Control_Panel_XBee_Sender(object):
         self._progress.canceled.connect(lambda: self._cancel())
         self._progress.setWindowTitle("Sending {}s".format(self._name))
         self._progress.setLabelText("Initializing...")
+
+    def connect_accepted(self, callback):
+        self._progress.accepted.connect(callback)
+
+    def start(self):
+        self._controller.add_packet_callback(self._ack_message,
+                                             self._receive_ack)
+
+        # Create a progress dialog and send the data to the vehicles.
         self._progress.open()
 
         for vehicle in self._data:

--- a/core/Threadable.py
+++ b/core/Threadable.py
@@ -27,3 +27,11 @@ class Threadable(object):
         """
 
         self._thread_manager.interrupt(self._name)
+
+    @property
+    def thread_name(self):
+        """
+        Retrieve the name of this thread.
+        """
+
+        return self._name

--- a/environment/Environment.py
+++ b/environment/Environment.py
@@ -6,6 +6,7 @@ from ..trajectory.Servo import Servo
 from ..vehicle.Vehicle import Vehicle
 from ..zigbee.XBee_Sensor_Physical import XBee_Sensor_Physical
 from ..zigbee.XBee_Sensor_Simulator import XBee_Sensor_Simulator
+from ..zigbee.XBee_Settings_Receiver import XBee_Settings_Receiver
 
 from dronekit import LocationLocal
 
@@ -77,6 +78,7 @@ class Environment(object):
 
         self.arguments = arguments
         self.settings = self.arguments.get_settings("environment")
+
         self._distance_sensors = None
 
         # Servo pins of the flight controller for distance sensor rotation
@@ -89,6 +91,8 @@ class Environment(object):
         self._measurements_valid = False
         self._packet_callbacks = {}
         self._setup_xbee_sensor()
+
+        self._settings_receiver = XBee_Settings_Receiver(self)
 
         if self.settings.get("infrared_sensor"):
             from ..control.Infrared_Sensor import Infrared_Sensor

--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -45,6 +45,23 @@
             }
         }
     },
+    "control_panel_settings": {
+        "name": "Control panel (settings view)",
+        "settings": {
+            "settings_max_retries": {
+                "help": "Number of retries for every setting packet sent to a vehicle",
+                "type": "int",
+                "min": 1,
+                "default": 5
+            },
+            "settings_retry_interval": {
+                "help": "Frequency in seconds to retry sending a setting packet to a vehicle",
+                "type": "float",
+                "min": 0.0,
+                "default": 0.5
+            }
+        }
+    },
     "control_panel_waypoints": {
         "name": "Control panel (waypoints view)",
         "settings": {

--- a/tests/core_thread_manager.py
+++ b/tests/core_thread_manager.py
@@ -42,6 +42,7 @@ class TestCoreThreadManager(ThreadableTestCase):
     def test_register(self):
         # The thread storage must contain a registered thread.
         mock_thread = Mock_Thread(self.thread_manager)
+        self.assertEqual(mock_thread.thread_name, "mock_thread")
         self.thread_manager.register("mock_thread", mock_thread)
         self.assertEqual(self.thread_manager._threads, {
             "mock_thread": mock_thread

--- a/tests/xbee_packet.py
+++ b/tests/xbee_packet.py
@@ -115,36 +115,36 @@ class TestXBeePacket(unittest.TestCase):
 
         # Valid messages must be unpacked.
         self.packet.unserialize("\x06H\xe1zT4o\x9dA\xf6(\\E\xa5q\x9dA\x16\x00\x00\x00\x02")
-        self.assertEqual(self.packet._contents, {
+        self.assertEqual(self.packet.get_all(), {
             "specification": "waypoint_add",
             "latitude": 123456789.12,
             "longitude": 123496785.34,
             "index": 22,
             "to_id": 2
         })
-        self.assertFalse(self.packet._private)
+        self.assertFalse(self.packet.is_private())
 
-    def test_unserialize_object_pack(self):
+    def test_unserialize_object_packed(self):
         self.packet.unserialize("\n\x00\x00\x00\x00\x03bar\x01i*\x00\x00\x00\x01")
-        self.assertEqual(self.packet._contents, {
+        self.assertEqual(self.packet.get_all(), {
             "specification": "setting_add",
             "index": 0,
             "key": "bar",
             "value": 42,
             "to_id": 1
         })
-        self.assertFalse(self.packet._private)
+        self.assertFalse(self.packet.is_private())
 
     def test_unserialize_object_compressed(self):
         self.packet.unserialize("\n\x01\x00\x00\x00\x05items\x00\x11x\x9c\x8b6\xd4Q0\xd2Q0\x8e\x05\x00\t\x85\x01\xe7\x01")
-        self.assertEqual(self.packet._contents, {
+        self.assertEqual(self.packet.get_all(), {
             "specification": "setting_add",
             "index": 1,
             "key": "items",
             "value": [1,2,3],
             "to_id": 1
         })
-        self.assertFalse(self.packet._private)
+        self.assertFalse(self.packet.is_private())
 
     def test_is_private(self):
         # The private property should be returned.

--- a/tests/xbee_packet.py
+++ b/tests/xbee_packet.py
@@ -84,6 +84,24 @@ class TestXBeePacket(unittest.TestCase):
         packed_message = self.packet.serialize()
         self.assertEqual(packed_message, "\x06H\xe1zT4o\x9dA\xf6(\\E\xa5q\x9dA\x16\x00\x00\x00\x02")
 
+    def test_serialize_object_packed(self):
+        self.packet.set("specification", "setting_add")
+        self.packet.set("key", "bar")
+        self.packet.set("value", 42)
+        self.packet.set("to_id", 1)
+
+        packed_message = self.packet.serialize()
+        self.assertEqual(packed_message, "\n\x03bar\x01i*\x00\x00\x00\x01")
+
+    def test_serialize_object_compressed(self):
+        self.packet.set("specification", "setting_add")
+        self.packet.set("key", "items")
+        self.packet.set("value", [1,2,3])
+        self.packet.set("to_id", 1)
+
+        packed_message = self.packet.serialize()
+        self.assertEqual(packed_message, "\n\x05items\x00\x11x\x9c\x8b6\xd4Q0\xd2Q0\x8e\x05\x00\t\x85\x01\xe7\x01")
+
     def test_unserialize(self):
         # Empty strings must be refused.
         with self.assertRaises(struct.error):
@@ -101,6 +119,26 @@ class TestXBeePacket(unittest.TestCase):
             "longitude": 123496785.34,
             "index": 22,
             "to_id": 2
+        })
+        self.assertFalse(self.packet._private)
+
+    def test_unserialize_object_pack(self):
+        self.packet.unserialize("\n\x03bar\x01i*\x00\x00\x00\x01")
+        self.assertEqual(self.packet._contents, {
+            "specification": "setting_add",
+            "key": "bar",
+            "value": 42,
+            "to_id": 1
+        })
+        self.assertFalse(self.packet._private)
+
+    def test_unserialize_object_compressed(self):
+        self.packet.unserialize("\n\x05items\x00\x11x\x9c\x8b6\xd4Q0\xd2Q0\x8e\x05\x00\t\x85\x01\xe7\x01")
+        self.assertEqual(self.packet._contents, {
+            "specification": "setting_add",
+            "key": "items",
+            "value": [1,2,3],
+            "to_id": 1
         })
         self.assertFalse(self.packet._private)
 

--- a/tests/xbee_packet.py
+++ b/tests/xbee_packet.py
@@ -86,21 +86,23 @@ class TestXBeePacket(unittest.TestCase):
 
     def test_serialize_object_packed(self):
         self.packet.set("specification", "setting_add")
+        self.packet.set("index", 0)
         self.packet.set("key", "bar")
         self.packet.set("value", 42)
         self.packet.set("to_id", 1)
 
         packed_message = self.packet.serialize()
-        self.assertEqual(packed_message, "\n\x03bar\x01i*\x00\x00\x00\x01")
+        self.assertEqual(packed_message, "\n\x00\x00\x00\x00\x03bar\x01i*\x00\x00\x00\x01")
 
     def test_serialize_object_compressed(self):
         self.packet.set("specification", "setting_add")
+        self.packet.set("index", 1)
         self.packet.set("key", "items")
         self.packet.set("value", [1,2,3])
         self.packet.set("to_id", 1)
 
         packed_message = self.packet.serialize()
-        self.assertEqual(packed_message, "\n\x05items\x00\x11x\x9c\x8b6\xd4Q0\xd2Q0\x8e\x05\x00\t\x85\x01\xe7\x01")
+        self.assertEqual(packed_message, "\n\x01\x00\x00\x00\x05items\x00\x11x\x9c\x8b6\xd4Q0\xd2Q0\x8e\x05\x00\t\x85\x01\xe7\x01")
 
     def test_unserialize(self):
         # Empty strings must be refused.
@@ -123,9 +125,10 @@ class TestXBeePacket(unittest.TestCase):
         self.assertFalse(self.packet._private)
 
     def test_unserialize_object_pack(self):
-        self.packet.unserialize("\n\x03bar\x01i*\x00\x00\x00\x01")
+        self.packet.unserialize("\n\x00\x00\x00\x00\x03bar\x01i*\x00\x00\x00\x01")
         self.assertEqual(self.packet._contents, {
             "specification": "setting_add",
+            "index": 0,
             "key": "bar",
             "value": 42,
             "to_id": 1
@@ -133,9 +136,10 @@ class TestXBeePacket(unittest.TestCase):
         self.assertFalse(self.packet._private)
 
     def test_unserialize_object_compressed(self):
-        self.packet.unserialize("\n\x05items\x00\x11x\x9c\x8b6\xd4Q0\xd2Q0\x8e\x05\x00\t\x85\x01\xe7\x01")
+        self.packet.unserialize("\n\x01\x00\x00\x00\x05items\x00\x11x\x9c\x8b6\xd4Q0\xd2Q0\x8e\x05\x00\t\x85\x01\xe7\x01")
         self.assertEqual(self.packet._contents, {
             "specification": "setting_add",
+            "index": 1,
             "key": "items",
             "value": [1,2,3],
             "to_id": 1

--- a/tests/xbee_settings_receiver.py
+++ b/tests/xbee_settings_receiver.py
@@ -22,7 +22,7 @@ class TestXBeeSettingsReceiver(ThreadableTestCase, USBManagerTestCase, SettingsT
                                              usb_manager=self.usb_manager)
         self.xbee = self.environment.get_xbee_sensor()
 
-        self.settings_receiver = XBee_Settings_Receiver(self.environment)
+        self.settings_receiver = self.environment._settings_receiver
 
     def test_setup(self):
         self.assertEqual(self.settings_receiver._environment, self.environment)

--- a/tests/xbee_settings_receiver.py
+++ b/tests/xbee_settings_receiver.py
@@ -112,4 +112,4 @@ class TestXBeeSettingsReceiver(ThreadableTestCase, USBManagerTestCase, SettingsT
 
         self.assertEqual(Settings.settings_files, {})
         self.assertEqual(self.arguments.groups, {})
-        interrupt_mock.assert_called_once_with()
+        interrupt_mock.assert_called_once_with("xbee_sensor")

--- a/tests/xbee_settings_receiver.py
+++ b/tests/xbee_settings_receiver.py
@@ -1,0 +1,115 @@
+import json
+from StringIO import StringIO
+from mock import Mock, mock_open, patch
+from ..core.Thread_Manager import Thread_Manager
+from ..environment.Environment import Environment
+from ..settings import Arguments, Settings
+from ..zigbee.XBee_Sensor_Simulator import XBee_Sensor_Simulator
+from ..zigbee.XBee_Packet import XBee_Packet
+from ..zigbee.XBee_Settings_Receiver import XBee_Settings_Receiver
+from core_thread_manager import ThreadableTestCase
+from core_usb_manager import USBManagerTestCase
+from settings import SettingsTestCase
+
+class TestXBeeSettingsReceiver(ThreadableTestCase, USBManagerTestCase, SettingsTestCase):
+    def setUp(self):
+        super(TestXBeeSettingsReceiver, self).setUp()
+
+        self.arguments = Arguments("settings.json", [
+            "--xbee-type", "simulator", "--no-infrared-sensor"
+        ])
+        self.environment = Environment.setup(self.arguments,
+                                             usb_manager=self.usb_manager)
+        self.xbee = self.environment.get_xbee_sensor()
+
+        self.settings_receiver = XBee_Settings_Receiver(self.environment)
+
+    def test_setup(self):
+        self.assertEqual(self.settings_receiver._environment, self.environment)
+        self.assertEqual(self.settings_receiver._arguments, self.arguments)
+        self.assertEqual(self.settings_receiver._xbee, self.xbee)
+        self.assertEqual(self.settings_receiver._thread_manager, self.environment.thread_manager)
+        self.assertEqual(self.settings_receiver._new_settings, {})
+        self.assertIn("setting_clear", self.environment._packet_callbacks.keys())
+        self.assertIn("setting_add", self.environment._packet_callbacks.keys())
+        self.assertIn("setting_done", self.environment._packet_callbacks.keys())
+
+    @patch.object(XBee_Sensor_Simulator, "enqueue")
+    def test_clear(self, enqueue_mock):
+        packet = XBee_Packet()
+        packet.set("specification", "setting_clear")
+        packet.set("to_id", self.xbee.id)
+
+        self.environment.receive_packet(packet)
+
+        self.assertEqual(enqueue_mock.call_count, 1)
+        args, kwargs = enqueue_mock.call_args
+        self.assertEqual(len(args), 1)
+        self.assertIsInstance(args[0], XBee_Packet)
+        self.assertEqual(args[0].get_all(), {
+            "specification": "setting_ack",
+            "next_index": 0,
+            "sensor_id": self.xbee.id
+        })
+        self.assertEqual(kwargs, {"to": 0})
+
+        self.assertEqual(Settings.settings_files, {})
+        self.assertEqual(self.arguments.groups, {})
+
+    @patch.object(XBee_Sensor_Simulator, "enqueue")
+    def test_add(self, enqueue_mock):
+        packet = XBee_Packet()
+        packet.set("specification", "setting_add")
+        packet.set("index", 0)
+        packet.set("key", "home_location")
+        packet.set("value", (1, 2))
+        packet.set("to_id", self.xbee.id)
+
+        self.environment.receive_packet(packet)
+
+        self.assertEqual(enqueue_mock.call_count, 1)
+        args, kwargs = enqueue_mock.call_args
+        self.assertEqual(len(args), 1)
+        self.assertIsInstance(args[0], XBee_Packet)
+        self.assertEqual(args[0].get_all(), {
+            "specification": "setting_ack",
+            "next_index": 1,
+            "sensor_id": self.xbee.id
+        })
+        self.assertEqual(kwargs, {"to": 0})
+
+        self.assertEqual(self.settings_receiver._new_settings, {"home_location": (1, 2)})
+
+    @patch.object(Thread_Manager, "interrupt")
+    def test_done(self, interrupt_mock):
+        new_settings = {
+            "home_location": (1, 2),
+            "closeness": 0.0,
+            "synchronize": True
+        }
+        pretty_json = json.dumps(new_settings, indent=4, sort_keys=True)
+        self.settings_receiver._new_settings = new_settings
+
+        packet = XBee_Packet()
+        packet.set("specification", "setting_done")
+        packet.set("to_id", self.xbee.id)
+
+        # Override the open function used in the XBee_Settings_Receiver so that 
+        # it does not actually write a file. Instead, make an Mock that 
+        # simulated the open function. Additionally, attach a wrapper mock to 
+        # the file's write function so that we can intercept the written data 
+        # and check if it is correct.
+        output = StringIO()
+        open_mock = mock_open()
+        write_mock = Mock(wraps=output.write)
+        open_mock.return_value.attach_mock(write_mock, "write")
+        open_func = '{}.open'.format(XBee_Settings_Receiver.__module__)
+        with patch(open_func, open_mock, create=True):
+            self.environment.receive_packet(packet)
+
+        open_mock.assert_called_once_with(self.arguments.settings_file, 'w')
+        self.assertEqual(output.getvalue(), pretty_json)
+
+        self.assertEqual(Settings.settings_files, {})
+        self.assertEqual(self.arguments.groups, {})
+        interrupt_mock.assert_called_once_with()

--- a/trajectory/Mission.py
+++ b/trajectory/Mission.py
@@ -351,10 +351,7 @@ class Mission_Auto(Mission):
                     self.vehicle.set_next_waypoint()
                     next_waypoint += 1
 
-        if next_waypoint >= self.vehicle.count_waypoints():
-            return False
-
-        return True
+        return next_waypoint < self.vehicle.count_waypoints()
 
 class Mission_Guided(Mission):
     """

--- a/vehicle/Dronekit_Vehicle.py
+++ b/vehicle/Dronekit_Vehicle.py
@@ -1,6 +1,7 @@
 import time
 import dronekit
 from pymavlink import mavutil
+from Vehicle import Vehicle
 from MAVLink_Vehicle import MAVLink_Vehicle
 from ..settings.Arguments import Arguments
 

--- a/vehicle/MAVLink_Vehicle.py
+++ b/vehicle/MAVLink_Vehicle.py
@@ -47,12 +47,11 @@ class MAVLink_Vehicle(Vehicle):
         """
         Retrieve the Location object corresponding to a waypoint command with ID `waypoint`.
         """
-        if waypoint == 0:
-            return None
+
         if waypoint == -1:
             waypoint = self.commands.next
 
-        mission_item = self.commands[waypoint-1]
+        mission_item = self.commands[waypoint]
         if mission_item.command != mavutil.mavlink.MAV_CMD_NAV_WAYPOINT:
             return None
 

--- a/vehicle/Mock_Vehicle.py
+++ b/vehicle/Mock_Vehicle.py
@@ -21,7 +21,7 @@ LocalMessage = namedtuple('Message',['x', 'y', 'z'])
 class CommandSequence(object):
     def __init__(self, vehicle):
         self._vehicle = vehicle
-        self._next = 1
+        self._next = 0
         self._commands = []
 
     def takeoff(self, altitude):
@@ -53,7 +53,7 @@ class CommandSequence(object):
         self._commands = []
 
     def __getitem__(self, key):
-        return self._commands[key+1]
+        return self._commands[key]
 
     def download(self):
         pass
@@ -330,7 +330,7 @@ class Mock_Vehicle(MAVLink_Vehicle):
                     self._target_location = None
                     self._target_command = False
         elif self._mode.name == "AUTO" and self.commands.count > self.commands.next:
-            cmd = self.commands[self.commands.next-1]
+            cmd = self.commands[self.commands.next]
             self._parse_command(cmd)
         elif self._mode.name == "GUIDED":
             vNorth = self._velocity[0]

--- a/zigbee/XBee_Packet.py
+++ b/zigbee/XBee_Packet.py
@@ -197,16 +197,15 @@ class XBee_Packet(object):
         elif format == "@":
             is_packed, offset = self._read_packed("?", contents, offset)
             if is_packed:
-                object_format, offset = self._read_packed("B", contents,
-                                                                offset)
-                data, offset = self._read_packed(chr(object_format),
-                                                 contents, offset)
+                object_format, offset = self._read_packed("B", contents, offset)
+                data, offset = self._read_packed(chr(object_format), contents,
+                                                 offset)
             else:
                 length, offset = self._read_packed("B", contents, offset)
                 data_format = "{}s".format(length)
 
-                compressed, offset = self._read_packed(data_format,
-                                                       contents, offset)
+                compressed, offset = self._read_packed(data_format, contents,
+                                                       offset)
 
                 data = json.loads(zlib.decompress(compressed))
         else:

--- a/zigbee/XBee_Settings_Receiver.py
+++ b/zigbee/XBee_Settings_Receiver.py
@@ -63,4 +63,4 @@ class XBee_Settings_Receiver(object):
         # Clean up cached settings and stop the program so that we can restart 
         # it with the new settings.
         self._cleanup()
-        self._thread_manager.interrupt()
+        self._thread_manager.interrupt(self._xbee.thread_name)

--- a/zigbee/XBee_Settings_Receiver.py
+++ b/zigbee/XBee_Settings_Receiver.py
@@ -1,0 +1,66 @@
+import json
+from XBee_Packet import XBee_Packet
+from ..settings import Settings
+
+class XBee_Settings_Receiver(object):
+    """
+    Handler for receiving XBee status packets that change settings.
+    """
+
+    def __init__(self, environment):
+        self._environment = environment
+        self._arguments = self._environment.get_arguments()
+        self._xbee = self._environment.get_xbee_sensor()
+        self._thread_manager = self._environment.thread_manager
+        self._new_settings = {}
+
+        self._environment.add_packet_action("setting_clear", self._clear)
+        self._environment.add_packet_action("setting_add", self._add)
+        self._environment.add_packet_action("setting_done", self._done)
+
+    def _cleanup(self):
+        Settings.settings_files = {}
+        self._arguments.groups = {}
+        self._new_settings = {}
+
+    def _send_ack(self, index=-1):
+        packet = XBee_Packet()
+        packet.set("specification", "setting_ack")
+        packet.set("next_index", index + 1)
+        packet.set("sensor_id", self._xbee.id)
+
+        self._xbee.enqueue(packet, to=0)
+
+    def _clear(self, packet):
+        # Ignore packets that are not meant for us.
+        if packet.get("to_id") != self._xbee.id:
+            return
+
+        self._cleanup()
+        self._send_ack()
+
+    def _add(self, packet):
+        # Ignore packets that are not meant for us.
+        if packet.get("to_id") != self._xbee.id:
+            return
+
+        index = packet.get("index")
+        key = packet.get("key")
+        value = packet.get("value")
+
+        self._new_settings[key] = value
+
+        self._send_ack(index)
+
+    def _done(self, packet):
+        # Ignore packets that are not meant for us.
+        if packet.get("to_id") != self._xbee.id:
+            return
+
+        with open(self._arguments.settings_file, 'w') as settings_file:
+            json.dump(self._new_settings, settings_file, indent=4, sort_keys=True)
+
+        # Clean up cached settings and stop the program so that we can restart 
+        # it with the new settings.
+        self._cleanup()
+        self._thread_manager.interrupt()

--- a/zigbee/specifications.json
+++ b/zigbee/specifications.json
@@ -175,6 +175,10 @@
             "private": false
         },
         {
+            "name": "index",
+            "format": "i"
+        },
+        {
             "name": "key",
             "format": "$"
         },
@@ -195,8 +199,8 @@
             "private": false
         },
         {
-            "name": "key",
-            "format": "$"
+            "name": "next_index",
+            "format": "i"
         },
         {
             "name": "sensor_id",

--- a/zigbee/specifications.json
+++ b/zigbee/specifications.json
@@ -154,5 +154,65 @@
             "name": "to_id",
             "format": "B"
         }
+    ],
+    "setting_clear": [
+        {
+            "name": "id",
+            "format": "B",
+            "value": 9,
+            "private": false
+        },
+        {
+            "name": "to_id",
+            "format": "B"
+        }
+    ],
+    "setting_add": [
+        {
+            "name": "id",
+            "format": "B",
+            "value": 10,
+            "private": false
+        },
+        {
+            "name": "key",
+            "format": "$"
+        },
+        {
+            "name": "value",
+            "format": "@"
+        },
+        {
+            "name": "to_id",
+            "format": "B"
+        }
+    ],
+    "setting_ack": [
+        {
+            "name": "id",
+            "format": "B",
+            "value": 11,
+            "private": false
+        },
+        {
+            "name": "key",
+            "format": "$"
+        },
+        {
+            "name": "sensor_id",
+            "format": "B"
+        }
+    ],
+    "setting_done": [
+        {
+            "name": "id",
+            "format": "B",
+            "value": 12,
+            "private": false
+        },
+        {
+            "name": "to_id",
+            "format": "B"
+        }
     ]
 }


### PR DESCRIPTION
- Enable the control panel settings view to send settings to the vehicles (e1ba7e3).
- Reuse the waypoints sending code for the settings sending (4880ed3).
- Pack the settings key and value into the XBee packet using few bytes using a specialized string format and an object format that uses specific struct formats or JSON formatting and GZip compression (ce0c076, cleanup in later commits).
- Receive the settings in the vehicles to bundle them together and write it to a JSON settings file, also restarting the mission so that the settings are reloaded (b792481, wrapping up in later commits).
- Add methods to the settings form widgets to get the changed value, check if it is different from the default, and to reset them to the current override or the package default. The first two methods are used for the sending algorithm, and the reset functionality is exposed to context menus. Some other UX changes related to size policies were made (2fe9e9e).

The sender and receiver have been tested with the actual hardware; unit tests are also provided. This PR can best be examined commit-by-commit, and the UX tweaks might need some testing in the control panel to ensure that it works fine in other window managers as well.
