### PR TITLE
Settings table widget

### DIFF
--- a/control_panel/Control_Panel_Planning_View.py
+++ b/control_panel/Control_Panel_Planning_View.py
@@ -10,7 +10,7 @@ import pyqtgraph as pg
 from PyQt4 import QtCore, QtGui
 from Control_Panel_View import Control_Panel_View, Control_Panel_View_Name
 from Control_Panel_Widgets import QToolBarFocus
-from Control_Panel_Settings_Widgets import SettingsWidget
+from Control_Panel_Settings_Widgets import SettingsToolbarWidget
 from ..planning.Runner import Planning_Runner
 
 class Planning_Sort_Order(object):
@@ -37,8 +37,7 @@ class Control_Panel_Planning_View(Control_Panel_View):
         components = ("planning", "planning_assignment", "planning_algorithm",
                       "planning_problem")
         for component in components:
-            form = SettingsWidget(self._controller.arguments, component,
-                                  toolbar=self._settings_toolbar)
+            form = SettingsToolbarWidget(self._controller.arguments, component)
 
             self._settings_toolbar.addWidget(form)
             self._forms[component] = form

--- a/control_panel/Control_Panel_Planning_View.py
+++ b/control_panel/Control_Panel_Planning_View.py
@@ -413,8 +413,7 @@ class Control_Panel_Planning_View(Control_Panel_View):
         # Update the settings from the toolbox forms.
         for component, form in self._forms.iteritems():
             settings = self._controller.arguments.get_settings(component)
-            values, allowed = form.get_values()
-            disallowed = [key for key, value in allowed.iteritems() if not value]
+            values, disallowed = form.get_all_values()
             if disallowed:
                 keys = ", ".join("'{}'".format(key) for key in disallowed)
                 QtGui.QMessageBox.critical(self._controller.central_widget,

--- a/control_panel/Control_Panel_Planning_View.py
+++ b/control_panel/Control_Panel_Planning_View.py
@@ -10,7 +10,7 @@ import pyqtgraph as pg
 from PyQt4 import QtCore, QtGui
 from Control_Panel_View import Control_Panel_View, Control_Panel_View_Name
 from Control_Panel_Widgets import QToolBarFocus
-from Control_Panel_Settings_Widgets import SettingsToolbarWidget
+from Control_Panel_Settings_Widgets import SettingsTableWidget
 from ..planning.Runner import Planning_Runner
 
 class Planning_Sort_Order(object):
@@ -21,6 +21,8 @@ class Control_Panel_Planning_View(Control_Panel_View):
     def show(self):
         self._add_menu_bar()
 
+        # Set up the planning runner and related state and update variables.
+        self._running = False
         self._runner = Planning_Runner(self._controller.arguments,
                                        self._controller.thread_manager,
                                        self.iteration_callback)
@@ -28,77 +30,83 @@ class Control_Panel_Planning_View(Control_Panel_View):
         self._updated = False
         self._update_interval = self._settings.get("planning_update_interval")
 
-        # Create the settings toolbar.
-        self._settings_toolbar = QToolBarFocus(self._controller.app, "Settings")
-        self._settings_toolbar.setMovable(False)
-        self._settings_toolbar.setStyleSheet("QToolBar {spacing: 8px;}")
-
-        self._forms = {}
-        components = ("planning", "planning_assignment", "planning_algorithm",
-                      "planning_problem")
-        for component in components:
-            form = SettingsToolbarWidget(self._controller.arguments, component)
-
-            self._settings_toolbar.addWidget(form)
-            self._forms[component] = form
-
-        self._controller.window.addToolBar(self._settings_toolbar)
-
-        # Create the actions toolbar
-        self._start_action = QtGui.QAction(QtGui.QIcon("assets/start.png"),
-                                           "Start",
-                                           self._controller.central_widget)
-        self._start_action.triggered.connect(self._start)
-
-        self._stop_action = QtGui.QAction(QtGui.QIcon("assets/stop.png"),
-                                           "Stop",
-                                           self._controller.central_widget)
-        self._stop_action.setEnabled(False)
-        self._stop_action.triggered.connect(self._stop)
-
-        actions_toolbar = self._controller.window.addToolBar("Planning")
-        actions_toolbar.setMovable(False)
-        actions_toolbar.setSizePolicy(QtGui.QSizePolicy.Minimum,
-                                      QtGui.QSizePolicy.Preferred)
-        actions_toolbar.setStyleSheet("QToolBar {spacing: 8px;}")
-        actions_toolbar.addAction(self._start_action)
-        actions_toolbar.addAction(self._stop_action)
-
+        # The fixed plot dimensions upon which we base our layout sizes as well 
+        # as the plot canvases themselves. This avoids laggy resize events.
         self._plot_width, self._plot_height = self._settings.get("planning_plot_dimensions")
 
-        # Create a progress bar.
+        # Create the progress bar.
         self._progress = QtGui.QProgressBar()
         self._progress.setMaximumWidth(self._plot_width)
 
+        # Create a select button for selecting an individual feasible solution.
         self._selectButton = QtGui.QPushButton()
         self._selectButton.setText("Select")
         self._selectButton.setToolTip("Select current solution to use waypoints from")
         self._selectButton.setEnabled(False)
         self._selectButton.clicked.connect(self._select)
 
-        self._overview_items = 2
-
-        self._item_width = self._plot_width / 4
-        self._item_height = self._plot_height / 4
-
+        # Create a list widget for selecting between different plots, namely 
+        # the Pareto front plot, a graph with statistics and result plots of 
+        # individual solutions. The list widget contains labels, current values 
+        # of objective functions and/or miniature plot images.
         self._listWidget = QtGui.QListWidget()
 
+        # The size of miniature plot images in the list widget.
+        self._item_width = self._plot_width / 3
+        self._item_height = self._plot_height / 3
+
+        # The number of items at the start of the list widget that are not 
+        # individual solution plots; namely, the Pareto front and statistics 
+        # graph. This is used for index conversion between the list widget and 
+        # the planning population.
+        self._overview_items = 2
+
+        # Create a stacked layout for switching between the plot widgets, and 
+        # connect it to the list widget and instant redrawing of the plot.
         self._stackedLayout = QtGui.QStackedLayout()
         self._listWidget.currentRowChanged.connect(self._stackedLayout.setCurrentIndex)
         self._stackedLayout.currentChanged.connect(lambda i: self._redraw(i))
 
+        # Create the settings table toolboxes.
+        self._forms = {}
+        components = ("planning", "planning_assignment", "planning_algorithm",
+                      "planning_problem")
+
+        toolbox = QtGui.QToolBox()
+        for component in components:
+            form = SettingsTableWidget(self._controller.arguments, component)
+
+            title = form.get_title()
+            index = toolbox.addItem(form, title)
+            toolbox.setItemToolTip(index, title)
+
+            self._forms[component] = form
+        
+        # Create the sort selector.
         self._sortSelector = QtGui.QComboBox()
         self._sortSelector.currentIndexChanged.connect(lambda i: self._resort(i))
 
+        # Create the toggle button (using the stopped state as default).
+        self._toggle_button = QtGui.QPushButton(QtGui.QIcon("assets/start.png"), "Start")
+        self._toggle_button.clicked.connect(self._toggle)
+
+        # Create the form layout and add the sort selector and toggle button.
+        formLayout = QtGui.QFormLayout()
+        formLayout.addRow("Sort order:", self._sortSelector)
+        formLayout.addRow(self._toggle_button)
+
+        # Create the tab widget.
+        self._tabWidget = QtGui.QTabWidget()
+        self._tabWidget.addTab(toolbox, "Settings")
+        self._tabWidget.addTab(self._listWidget, "Runner state")
+
+        # Initialize more state variables and setup plots for initial display.
         self._init()
         self._setup()
 
-        # Create the layout and add the widgets.
-        formLayout = QtGui.QFormLayout()
-        formLayout.addRow("Sort order:", self._sortSelector)
-
+        # Create the layout and add all the widgets and other layouts into it.
         leftBox = QtGui.QVBoxLayout()
-        leftBox.addWidget(self._listWidget)
+        leftBox.addWidget(self._tabWidget)
         leftBox.addLayout(formLayout)
 
         topLayout = QtGui.QHBoxLayout()
@@ -374,7 +382,36 @@ class Control_Panel_Planning_View(Control_Panel_View):
                 self._listWidget.setCurrentRow(item_index)
                 return
 
+    def _toggle(self):
+        """
+        Handle the toggle button to toggle the state of the planning runner 
+        (start or stop).
+        """
+
+        if not self._running:
+            self._start()
+        else:
+            self._stop()
+
+    def _update_running(self, running):
+        """
+        Toggle the running state of the toggle button (started of stopped).
+        """
+
+        if not running:
+            self._toggle_button.setIcon(QtGui.QIcon("assets/start.png"))
+            self._toggle_button.setText("Start")
+        else:
+            self._toggle_button.setIcon(QtGui.QIcon("assets/stop.png"))
+            self._toggle_button.setText("Stop")
+
+        self._running = running
+
     def _start(self):
+        # Update the toggle button state
+        self._update_running(True)
+
+        # Update the settings from the toolbox forms.
         for component, form in self._forms.iteritems():
             settings = self._controller.arguments.get_settings(component)
             for key, value in form.get_values().iteritems():
@@ -383,29 +420,36 @@ class Control_Panel_Planning_View(Control_Panel_View):
                 except ValueError:
                     return
 
-        self._settings_toolbar.layout().setExpanded(False)
-        self._start_action.setEnabled(False)
-        self._stop_action.setEnabled(True)
-        self._selectButton.setEnabled(False)
-
+        # Set the running state for the planning runner, and stop the XBee from 
+        # taking up cycles during the algorithm.
         self._controller.xbee.deactivate()
         self._runner.activate()
 
+        # Change the tab widget to show the runner state.
+        self._tabWidget.setCurrentIndex(1)
+        self._selectButton.setEnabled(False)
+
+        # Update the progress bar to show the correct iteration completion.
         t_max = self._runner.get_iteration_limit()
 
         self._progress.setValue(0)
         self._progress.setRange(0, t_max)
 
+        # Clean up an old run and set up the new Pareto front plot and label.
         self._cleanup()
         self._setup()
 
+        # Ensure we are allowed to make the matplotlib figures that we need, 
+        # but do not allow more for memory leak detection.
         size = self._runner.get_population_size()
         plt.rcParams.update({'figure.max_open_warning': size + 1})
 
+        # Create the statistics graph.
         self._graph = self._create_graph()
         self._graph_label = self._add_list_item("Statistics", self._graph)
         self._graph_label.setStyleSheet("border-top: 1px solid grey")
 
+        # Create the plots and labels for the individual solutions.
         for i in range(1, size + 1):
             axes, canvas = self._create_plot()
 
@@ -417,6 +461,7 @@ class Control_Panel_Planning_View(Control_Panel_View):
             self._individual_axes.append(axes)
             self._individual_canvases.append(canvas)
 
+        # Start the timer for updating plots and labels.
         self._timer = QtCore.QTimer()
         self._timer.setInterval(self._update_interval * 1000)
         self._timer.setSingleShot(False)
@@ -424,20 +469,24 @@ class Control_Panel_Planning_View(Control_Panel_View):
         self._timer.start()
 
     def _stop(self):
+        # Set the planning runner state to stopped, and reactivate the XBee.
+        self._update_running(False)
         self._runner.deactivate()
         self._controller.xbee.activate()
 
-        self._start_action.setEnabled(True)
-        self._stop_action.setEnabled(False)
-
     def _check(self):
+        # Update progress bar completion percentage every time, not only when 
+        # new iteration callback data has arrived.
         self._progress.setValue(self._runner.get_iteration_current())
 
+        # Stop the runner and update timer if the planning is done, then check 
+        # for updates and final data.
         if self._runner.done:
             self._stop()
             self._timer.stop()
 
         if self._updated:
+            # Update the graph with updated iteration statistics.
             c = 0
             for name, data in self._graph_data.iteritems():
                 if name not in self._graph_plots:
@@ -453,6 +502,7 @@ class Control_Panel_Planning_View(Control_Panel_View):
             self._draw_list_item(self._graph_label, self._graph)
 
         if self._runner.done or self._updated:
+            # Draw the plots for the Pareto front and any selected solution.
             self._runner.make_pareto_plot(self._front_axes)
             self._front_canvas.draw()
             self._draw_list_item(self._front_label, self._front_canvas)

--- a/control_panel/Control_Panel_Reconstruction_View.py
+++ b/control_panel/Control_Panel_Reconstruction_View.py
@@ -8,13 +8,11 @@ import json
 import matplotlib
 matplotlib.use("Qt4Agg")
 import matplotlib.pyplot as plt
-import os.path
 import pyqtgraph as pg
 import thread
-from collections import OrderedDict
-from functools import partial
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 from PyQt4 import QtGui, QtCore
+from Control_Panel_Settings_Widgets import SettingsTableWidget
 from Control_Panel_View import Control_Panel_View
 from ..reconstruction.Coordinator import Coordinator
 from ..reconstruction.Dataset_Buffer import Dataset_Buffer
@@ -172,203 +170,8 @@ class Table(object):
         for index in reversed(range(self._table.rowCount())):
             self._table.removeRow(index)
 
-class Panel(QtGui.QTableWidget):
-    def __init__(self, parent, settings):
-        """
-        Initialize the panel object.
-        """
-
-        QtGui.QTableWidget.__init__(self, parent)
-
-        self._settings = settings
-        self._source = None
-
-        # Maintain an object that maps a label to a lambda function responsible
-        # for returning the value of the widget. This is used to fetch all entered
-        # values in a structured manner when the reconstruction process is started.
-        self._data = {}
-
-        # Create the key and value columns.
-        self.setColumnCount(2)
-
-        # Let the columns take up the entire width of the table.
-        for index in range(2):
-            self.horizontalHeader().setResizeMode(index, QtGui.QHeaderView.Stretch)
-
-        # Hide the horizontal and vertical headers.
-        self.horizontalHeader().hide()
-        self.verticalHeader().hide()
-
-        # Populate the panel with default items.
-        self._items = OrderedDict()
-
-        reconstructor = QtGui.QComboBox()
-        reconstructor.addItems(["Least squares", "SVD", "Truncated SVD"])
-        reconstructor.setCurrentIndex(2)
-
-        self._register("Reconstructor", reconstructor,
-                       partial(lambda reconstructor: str(reconstructor.currentText()), reconstructor))
-        self._render()
-
-    @property
-    def source(self):
-        """
-        Return the data source corresponding to this panel.
-        """
-
-        return self._source
-
-    def get(self, label):
-        """
-        Get the value of the widget identified by its `label` using
-        the associated lambda function.
-        """
-
-        if label not in self._data:
-            raise ValueError("Lambda function for label '{}' has not been registered".format(label))
-
-        return self._data[label]()
-
-    def _register(self, label, widget, lambda_function):
-        """
-        Register an item for the table with a `label`, a `widget` and a
-        `lambda_function` that takes care of fetching the value of the widget.
-        """
-
-        self._items[label] = widget
-        self._data[label] = lambda_function
-
-    def _render(self):
-        """
-        Render the panel with all registered items.
-        """
-
-        for label, widget in self._items.iteritems():
-            position = self.rowCount()
-
-            label = QtGui.QTableWidgetItem("{}:".format(label))
-            label.setFlags(label.flags() & ~QtCore.Qt.ItemIsEditable & ~QtCore.Qt.ItemIsSelectable)
-
-            self.insertRow(position)
-            self.setItem(position, 0, label)
-            self.setCellWidget(position, 1, widget)
-
-class Dataset_Panel(Panel):
-    def __init__(self, parent, settings):
-        """
-        Initialize the dataset panel object.
-        """
-
-        super(Dataset_Panel, self).__init__(parent, settings)
-
-        self._source = Source.DATASET
-
-    def _render(self):
-        """
-        Render the panel with both the default items and items
-        that are specific to this data source.
-        """
-
-        input_elements = {
-            "dataset_calibration_file": "Calibration file",
-            "dataset_file": "File"
-        }
-
-        for key, label in input_elements.iteritems():
-            file_box = QtGui.QLineEdit()
-            file_box.setText(self._settings.get(key))
-
-            self._register(label, file_box, partial(
-                lambda file_box: "assets/dataset_{}.csv".format(file_box.text()), file_box
-            ))
-
-        super(Dataset_Panel, self)._render()
-
-class Dump_Panel(Panel):
-    def __init__(self, parent, settings):
-        """
-        Initialize the dump panel object.
-        """
-
-        super(Dump_Panel, self).__init__(parent, settings)
-
-        self._source = Source.DUMP
-
-    def _render(self):
-        """
-        Render the panel with both the default items and items
-        that are specific to this data source.
-        """
-
-        input_elements = {
-            "dump_calibration_file": "Calibration file",
-            "dump_file": "File"
-        }
-
-        for key, label in input_elements.iteritems():
-            file_box = QtGui.QLineEdit()
-            file_box.setText(self._settings.get(key))
-
-            self._register(label, file_box, partial(
-                lambda file_box: "assets/dump_{}.json".format(file_box.text()), file_box
-            ))
-
-        super(Dump_Panel, self)._render()
-
-class Stream_Panel(Panel):
-    def __init__(self, parent, settings):
-        """
-        Initialize the stream panel object.
-        """
-
-        super(Stream_Panel, self).__init__(parent, settings)
-
-        self._source = Source.STREAM
-
-    def _render(self):
-        """
-        Render the panel with both the default items and items
-        that are specific to this data source.
-        """
-
-        # Create the origin and size inputs.
-        for label in ["Origin", "Size"]:
-            widget = QtGui.QWidget()
-
-            widget_layout = QtGui.QHBoxLayout()
-            widget_layout.setContentsMargins(0, 0, 0, 0)
-
-            x_box = QtGui.QLineEdit()
-            x_box.setText("0")
-            y_box = QtGui.QLineEdit()
-            y_box.setText("0")
-
-            widget_layout.addWidget(x_box)
-            widget_layout.addWidget(y_box)
-            widget.setLayout(widget_layout)
-
-            self._register(label, widget, partial(
-                lambda x_box, y_box: [int(x_box.text()), int(y_box.text())], x_box, y_box
-            ))
-
-        # Create the record and calibrate checkboxes.
-        for label in ["Record", "Calibrate"]:
-            checkbox = QtGui.QCheckBox("Yes")
-            self._register(label, checkbox, partial(
-                lambda checkbox: checkbox.isChecked(), checkbox
-            ))
-
-        # Create the calibration file input.
-        file_box = QtGui.QLineEdit()
-
-        self._register("Calibration file", file_box, partial(
-            lambda file_box: "assets/stream_{}.json".format(file_box.text()), file_box
-        ))
-
-        super(Stream_Panel, self)._render()
-
 class Stream_Recorder(object):
-    def __init__(self, central_widget=None, options=None):
+    def __init__(self, controller=None, settings=None):
         """
         Initialize the stream recorder object.
 
@@ -376,17 +179,15 @@ class Stream_Recorder(object):
         enabled. When recording is stopped, the captured data is exported to a dump file.
         """
 
-        if central_widget is None:
-            raise ValueError("Central widget for the stream recorder has not been provided.")
+        if controller is None:
+            raise ValueError("Controller for the stream recorder have not been provided.")
 
-        if options is None:
-            raise ValueError("Options for the stream recorder have not been provided.")
+        if settings is None:
+            raise ValueError("Settings for the stream recorder have not been provided.")
 
-        self._central_widget = central_widget
-
-        self._number_of_sensors = options["number_of_sensors"]
-        self._origin = options["origin"]
-        self._size = options["size"]
+        self._number_of_sensors = controller.xbee.number_of_sensors
+        self._origin = settings.get("stream_origin")
+        self._size = settings.get("stream_size")
 
         self._packets = []
 
@@ -397,12 +198,12 @@ class Stream_Recorder(object):
 
         self._packets.append(packet)
 
-    def export(self):
+    def export(self, central_widget):
         """
         Export the packets (along with network information) to a dump file.
         """
 
-        file_name = QtGui.QFileDialog.getSaveFileName(self._central_widget,
+        file_name = QtGui.QFileDialog.getSaveFileName(controller.central_widget,
                                                       "Export file", os.getcwd(),
                                                       "JSON files (*.json)")
 
@@ -419,12 +220,7 @@ class Stream_Recorder(object):
                 }, export_file)
         except IOError as e:
             message = "Could not open file '{}': {}".format(file_name, e.strerror)
-            QtGui.QMessageBox.critical(self._central_widget, "File error", message)
-
-class Source(object):
-    DATASET = "Dataset"
-    DUMP = "Dump"
-    STREAM = "Stream"
+            QtGui.QMessageBox.critical(controller.central_widget, "File error", message)
 
 class Control_Panel_Reconstruction_View(Control_Panel_View):
     def show(self):
@@ -453,19 +249,42 @@ class Control_Panel_Reconstruction_View(Control_Panel_View):
         tabs.addTab(self._table.create(), "Table")
 
         # Create the panels.
-        panels = QtGui.QTabWidget()
-        panels.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Expanding)
-        panels.addTab(Dataset_Panel(panels, self._settings), Source.DATASET)
-        panels.addTab(Dump_Panel(panels, self._settings), Source.DUMP)
-        panels.addTab(Stream_Panel(panels, self._settings), Source.STREAM)
+        self._sources = [
+            {
+                "title": "Dataset",
+                "component": "reconstruction_dataset",
+                "buffer": Dataset_Buffer
+            },
+            {
+                "title": "Dump",
+                "component": "reconstruction_dump",
+                "buffer": Dump_Buffer
+            },
+            {
+                "title": "Stream",
+                "component": "reconstruction_stream",
+                "buffer": Stream_Buffer
+            },
+        ]
+
+        self._panels = QtGui.QTabWidget()
+        self._panels.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Expanding)
+
+        self._forms = []
+        for source in self._sources:
+            form = SettingsTableWidget(self._controller.arguments,
+                                       source["component"])
+            self._panels.addTab(form, source["title"])
+
+            self._forms.append(form)
 
         # Create the toggle button (using the stopped state as default).
         self._toggle_button = QtGui.QPushButton(QtGui.QIcon("assets/start.png"), "Start")
-        self._toggle_button.clicked.connect(lambda: self._toggle(panels.currentWidget()))
+        self._toggle_button.clicked.connect(self._toggle)
 
         # Create the layout and add the widgets.
         vbox_left = QtGui.QVBoxLayout()
-        vbox_left.addWidget(panels)
+        vbox_left.addWidget(self._panels)
         vbox_left.addWidget(self._toggle_button)
 
         vbox_right = QtGui.QVBoxLayout()
@@ -477,7 +296,7 @@ class Control_Panel_Reconstruction_View(Control_Panel_View):
         hbox.addLayout(vbox_left)
         hbox.addLayout(vbox_right)
 
-    def _toggle(self, parameters):
+    def _toggle(self):
         """
         Toggle the state of the reconstruction (start or stop).
         """
@@ -488,34 +307,66 @@ class Control_Panel_Reconstruction_View(Control_Panel_View):
             self._toggle_button.setIcon(QtGui.QIcon("assets/stop.png"))
             self._toggle_button.setText("Stop")
 
-            self._start(parameters)
+            self._start()
         else:
             self._toggle_button.setIcon(QtGui.QIcon("assets/start.png"))
             self._toggle_button.setText("Start")
 
-    def _start(self, parameters):
+    def _start(self):
         """
-        Start the reconstruction process with all parameters from the panel.
+        Start the reconstruction process.
         """
 
+        # Determine the current panel and update the settings from the form.
+        panel_id = self._panels.currentIndex()
+        source = self._sources[panel_id]
+        form = self._forms[panel_id]
+
+        settings = form.get_settings()
+        values, disallowed = form.get_all_values()
+        if disallowed:
+            keys = ", ".join("'{}'".format(key) for key in disallowed)
+            QtGui.QMessageBox.critical(self._controller.central_widget,
+                                       "Invalid value",
+                                       "The following settings have incorrect values: {}".format(form.get_title(), keys))
+            self._toggle()
+            return
+
+        for key, value in values.iteritems():
+            try:
+                settings.set(key, value)
+            except ValueError as e:
+                QtGui.QMessageBox.critical(self._controller.central_widget,
+                                           "Settings error", e.message)
+                self._toggle()
+                return
+
+
         # Fetch the settings for the reconstruction.
-        self._pause_time = self._settings.get("pause_time") * 1000
-        self._cmap = self._settings.get("cmap")
-        self._interpolation = self._settings.get("interpolation")
-        self._chunk_size = self._settings.get("chunk_size")
+        self._pause_time = self._settings.get("reconstruction_pause_time") * 1000
+        self._cmap = settings.get("cmap")
+        self._interpolation = settings.get("interpolation")
+        self._chunk_size = settings.get("chunk_size")
 
         # Create the buffer and reconstructor.
         try:
-            self._create_buffer(parameters)
-            self._create_reconstructor(parameters)
-        except Exception as exception:
-            QtGui.QMessageBox.critical(self._controller.central_widget, "Initialization error",
-                                       exception.message)
-            self._toggle(parameters)
+            self._create_buffer(source, settings)
+            self._create_reconstructor(settings)
+        except IOError as e:
+            QtGui.QMessageBox.critical(self._controller.central_widget,
+                                       "File error",
+                                       "Could not open file '{}': {}".format(e.filename, e.strerror))
+            self._toggle()
+            return
+        except Exception as e:
+            QtGui.QMessageBox.critical(self._controller.central_widget,
+                                       "Initialization error", e.message)
+            self._toggle()
             return
 
         # Create the coordinator.
-        self._coordinator = Coordinator(self._controller.arguments, self._buffer)
+        self._coordinator = Coordinator(self._controller.arguments,
+                                        self._buffer)
 
         # Clear the graph and table and setup the graph.
         self._graph.clear()
@@ -531,67 +382,34 @@ class Control_Panel_Reconstruction_View(Control_Panel_View):
         self._chunk_count = 0
         self._loop()
 
-    def _create_buffer(self, parameters):
+    def _create_buffer(self, source, settings):
         """
         Create the buffer for the reconstruction process (depending on the data source).
         """
 
-        if parameters.source == Source.DATASET or parameters.source == Source.DUMP:
-            calibration_file = parameters.get("Calibration file")
-            file = parameters.get("File")
+        buffer_class = source["buffer"]
+        self._buffer = buffer_class(settings)
 
-            for field in [calibration_file, file]:
-                if not os.path.exists(field):
-                    raise OSError("File '{}' does not exist.".format(field))
+        if isinstance(self._buffer, Stream_Buffer):
+            record = self._buffer.register_xbee(self._controller.xbee)
 
-            buffer_class = Dataset_Buffer if parameters.source == Source.DATASET else Dump_Buffer
-            self._buffer = buffer_class({
-                "calibration_file": calibration_file,
-                "file": file
-            })
-        elif parameters.source == Source.STREAM:
-            origin = parameters.get("Origin")
-            size = parameters.get("Size")
-            record = parameters.get("Record")
-            calibrate = parameters.get("Calibrate")
-            calibration_file = parameters.get("Calibration file")
+            if record:
+                # Create a stream recorder instance to record all incoming 
+                # packets. The existence of this object is enough to let the 
+                # loop handle the recording process.
+                self._stream_recorder = Stream_Recorder(self._controller, settings)
 
-            if not all(dimension > 0 for dimension in size):
-                raise ValueError("The network dimensions must be greater than zero.")
-
-            if not calibrate and not os.path.exists(calibration_file):
-                raise OSError("File '{}' does not exist.".format(calibration_file))
-
-            self._buffer = Stream_Buffer({
-                "number_of_sensors": self._controller.xbee.number_of_sensors,
-                "origin": origin,
-                "size": size,
-                "calibrate": calibrate,
-                "calibration_file": calibration_file
-            })
-            self._controller.xbee.set_buffer(self._buffer)
-
-            if record or calibrate:
-                # Create a stream recorder instance to record all incoming packets.
-                # The existence of this object is enough to let the loop handle the
-                # recording process.
-                self._stream_recorder = Stream_Recorder(self._controller.central_widget, {
-                    "number_of_sensors": self._controller.xbee.number_of_sensors,
-                    "origin": origin,
-                    "size": size
-                })
-
-    def _create_reconstructor(self, parameters):
+    def _create_reconstructor(self, settings):
         """
         Create the reconstructor for the reconstruction process.
         """
 
         reconstructors = {
-            "Least squares": Least_Squares_Reconstructor,
-            "SVD": SVD_Reconstructor,
-            "Truncated SVD": Truncated_SVD_Reconstructor
+            "Least_Squares_Reconstructor": Least_Squares_Reconstructor,
+            "SVD_Reconstructor": SVD_Reconstructor,
+            "Truncated_SVD_Reconstructor": Truncated_SVD_Reconstructor
         }
-        reconstructor_class = reconstructors[parameters.get("Reconstructor")]
+        reconstructor_class = reconstructors[settings.get("reconstructor")]
         self._reconstructor = reconstructor_class(self._controller.arguments)
 
     def _loop(self):

--- a/control_panel/Control_Panel_Reconstruction_View.py
+++ b/control_panel/Control_Panel_Reconstruction_View.py
@@ -9,6 +9,7 @@ import json
 import matplotlib
 matplotlib.use("Qt4Agg")
 import matplotlib.pyplot as plt
+import os
 import pyqtgraph as pg
 import thread
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
@@ -178,14 +179,16 @@ class Stream_Recorder(object):
         """
 
         if controller is None:
-            raise ValueError("Controller for the stream recorder have not been provided.")
+            raise ValueError("Controller for the stream recorder has not been provided.")
 
         if settings is None:
             raise ValueError("Settings for the stream recorder have not been provided.")
 
+        self._controller = controller
+
         self._number_of_sensors = controller.xbee.number_of_sensors
-        self._origin = settings.get("stream_origin")
-        self._size = settings.get("stream_size")
+        self._origin = settings.get("stream_network_origin")
+        self._size = settings.get("stream_network_size")
 
         self._packets = []
 
@@ -201,7 +204,7 @@ class Stream_Recorder(object):
         Export the packets (along with network information) to a dump file.
         """
 
-        file_name = QtGui.QFileDialog.getSaveFileName(controller.central_widget,
+        file_name = QtGui.QFileDialog.getSaveFileName(self._controller.central_widget,
                                                       "Export file", os.getcwd(),
                                                       "JSON files (*.json)")
 
@@ -218,7 +221,7 @@ class Stream_Recorder(object):
                 }, export_file)
         except IOError as e:
             message = "Could not open file '{}': {}".format(file_name, e.strerror)
-            QtGui.QMessageBox.critical(controller.central_widget, "File error", message)
+            QtGui.QMessageBox.critical(self._controller.central_widget, "File error", message)
 
 class Control_Panel_Reconstruction_View(Control_Panel_View):
     def show(self):
@@ -264,7 +267,7 @@ class Control_Panel_Reconstruction_View(Control_Panel_View):
                 "title": "Stream",
                 "component": "reconstruction_stream",
                 "buffer": Stream_Buffer
-            },
+            }
         ]
 
         self._panels = QtGui.QTabWidget()
@@ -331,7 +334,7 @@ class Control_Panel_Reconstruction_View(Control_Panel_View):
 
     def _update_form(self, index):
         """
-        Update the stacked widget with the reconstructor settings widget based
+        Update the stacked widget with the reconstructor settings based
         on the reconstructor combo box in the current source form.
         """
 
@@ -353,8 +356,8 @@ class Control_Panel_Reconstruction_View(Control_Panel_View):
 
     def _update_reconstructor(self, text):
         """
-        Update the stacked widget with the reconstructor settings widget based
-        on the `text` in the reconstructor combo box in the current source form.
+        Update the stacked widget with the reconstructor settings based on
+        the `text` in the reconstructor combo box in the current source form.
         """
 
         parts = str(text).split(' ')[:-1]

--- a/control_panel/Control_Panel_Settings_View.py
+++ b/control_panel/Control_Panel_Settings_View.py
@@ -81,9 +81,12 @@ class Control_Panel_Settings_View(Control_Panel_View):
 
     def _save(self):
         flat_settings = {}
+        disallowed = []
         for i, widget in enumerate(self._widgets):
             if widget is not None:
-                flat_settings.update(widget.get_values())
+                values, allowed = widget.get_values()
+                flat_settings.update(values)
+                disallowed.extend([(i, key) for key, value in allowed.iteritems() if not value])
 
         pretty_json = json.dumps(flat_settings, indent=4, sort_keys=True)
 
@@ -93,6 +96,17 @@ class Control_Panel_Settings_View(Control_Panel_View):
         textEdit = QtGui.QTextEdit()
         textEdit.setPlainText(pretty_json)
         textEdit.setReadOnly(True)
+
+        warnLayout = QtGui.QVBoxLayout()
+        for i, key in disallowed:
+            warnLayout.addWidget(QtGui.QLabel("Setting '{}' from component '{}' has incorrect value.".format(key, self._components[i])))
+
+        groupWarnings = QtGui.QGroupBox("Warnings")
+        groupWarnings.setLayout(warnLayout)
+
+        scrollWarnings = QtGui.QScrollArea()
+        scrollWarnings.setWidgetResizable(True)
+        scrollWarnings.setWidget(groupWarnings)
 
         groundCheckBox = QtGui.QCheckBox("Ground station")
         groundCheckBox.setChecked(True)
@@ -122,9 +136,9 @@ class Control_Panel_Settings_View(Control_Panel_View):
         groupBox = QtGui.QGroupBox("Save locations")
         groupBox.setLayout(boxLayout)
 
-        scrollArea = QtGui.QScrollArea()
-        scrollArea.setWidgetResizable(True)
-        scrollArea.setWidget(groupBox)
+        scrollBox = QtGui.QScrollArea()
+        scrollBox.setWidgetResizable(True)
+        scrollBox.setWidget(groupBox)
 
         dialogButtons = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel)
         dialogButtons.accepted.connect(dialog.accept)
@@ -132,7 +146,9 @@ class Control_Panel_Settings_View(Control_Panel_View):
 
         dialogLayout = QtGui.QVBoxLayout()
         dialogLayout.addWidget(textEdit)
-        dialogLayout.addWidget(scrollArea)
+        if disallowed:
+            dialogLayout.addWidget(scrollWarnings)
+        dialogLayout.addWidget(scrollBox)
         dialogLayout.addWidget(dialogButtons)
 
         dialog.setLayout(dialogLayout)

--- a/control_panel/Control_Panel_Settings_View.py
+++ b/control_panel/Control_Panel_Settings_View.py
@@ -99,7 +99,8 @@ class Control_Panel_Settings_View(Control_Panel_View):
 
         warnLayout = QtGui.QVBoxLayout()
         for i, key in disallowed:
-            warnLayout.addWidget(QtGui.QLabel("Setting '{}' from component '{}' has incorrect value.".format(key, self._components[i])))
+            message = "Setting '{}' from component '{}' has an incorrect value."
+            warnLayout.addWidget(QtGui.QLabel(message.format(key, self._components[i])))
 
         groupWarnings = QtGui.QGroupBox("Warnings")
         groupWarnings.setLayout(warnLayout)

--- a/control_panel/Control_Panel_Settings_Widgets.py
+++ b/control_panel/Control_Panel_Settings_Widgets.py
@@ -582,7 +582,8 @@ class FileFormWidget(TextFormWidget):
         if text == "":
             return None
 
-        # Final format conversion step
+        # Final format conversion step. We convert back any short formated file 
+        # name to the actual file name, if necessary.
         try:
             return self.settings.check_format(self.key, self.info, text)
         except ValueError as e:

--- a/control_panel/Control_Panel_Settings_Widgets.py
+++ b/control_panel/Control_Panel_Settings_Widgets.py
@@ -210,8 +210,9 @@ class SettingsWidget(QtGui.QWidget):
         Retrieve the current values from the input widgets that have changed
         from the default.
 
-        The returned dictionary contains the settings keys and the changed
-        values.
+        The returned values are two dictionaries. The first dictionary contains
+        the settings keys and the changed values, while the second dictionary
+        contains the allowed state of each value widget by their settings key.
         """
 
         values = {}
@@ -222,6 +223,26 @@ class SettingsWidget(QtGui.QWidget):
                 values[key] = widget.get_value()
 
         return values, allowed
+
+    def get_all_values(self):
+        """
+        Retrieve the current values from the input widgets, even when they are
+        the same as the default.
+
+        The returned values are a dictionary and a list. The dictionary contains
+        the settings keys and the current values, while the second list contains
+        the settings keys that have disallowed values.
+        """
+
+        values = {}
+        disallowed = []
+        for key, widget in self._value_widgets.iteritems():
+            if not widget.is_value_allowed():
+                disallowed.append(key)
+
+            values[key] = widget.get_value()
+
+        return values, disallowed
 
     def _trigger_parent_clicked(self):
         self.parentClicked.emit(self._settings.parent.component_name)

--- a/reconstruction/Buffer.py
+++ b/reconstruction/Buffer.py
@@ -2,17 +2,17 @@ import Queue
 from ..zigbee.XBee_Packet import XBee_Packet
 
 class Buffer(object):
-    def __init__(self, options=None):
+    def __init__(self, settings=None):
         """
         Initialize the buffer object.
         """
 
-        if options is None:
-            raise ValueError("Options for the buffer have not been provided.")
+        if settings is None:
+            raise ValueError("Settings for the buffer have not been provided.")
 
         self._number_of_sensors = 0
-        self._origin = [0, 0]
-        self._size = [0, 0]
+        self._origin = (0, 0)
+        self._size = (0, 0)
 
         self._queue = Queue.Queue()
         self._calibration = {}

--- a/reconstruction/Dataset_Buffer.py
+++ b/reconstruction/Dataset_Buffer.py
@@ -3,12 +3,12 @@ from Buffer import Buffer
 from ..zigbee.XBee_Packet import XBee_Packet
 
 class Dataset_Buffer(Buffer):
-    def __init__(self, options=None):
+    def __init__(self, settings=None):
         """
         Initialize the dataset buffer object.
         """
 
-        super(Dataset_Buffer, self).__init__(options)
+        super(Dataset_Buffer, self).__init__(settings)
 
         # Read the provided dataset file. The CSV file is a radio tomographic
         # imaging dataset provided by the University of Utah. Refer to
@@ -22,10 +22,11 @@ class Dataset_Buffer(Buffer):
             (21, 0), (18, 0), (15, 0), (12, 0), (9, 0), (6, 0), (2, 0)
         ]
         self._number_of_sensors = len(self._positions)
-        self._size = [21, 21]
+        self._size = (21, 21)
 
         # Read the data from the empty network (for calibration).
-        with open(options["calibration_file"], "r") as dataset_calibration_file:
+        calibration_filename = settings.get("dataset_calibration_file")
+        with open(calibration_filename, "r") as dataset_calibration_file:
             for line in csv.reader(dataset_calibration_file):
                 destination_id = int(line[0])
 
@@ -41,7 +42,7 @@ class Dataset_Buffer(Buffer):
                     self._calibration[(source, destination)] = rssi
 
         # Read the data from the nonempty network.
-        with open(options["file"], "r") as dataset_file:
+        with open(settings.get("dataset_file"), "r") as dataset_file:
             for line in csv.reader(dataset_file):
                 destination_id = int(line[0])
 

--- a/reconstruction/Dump_Buffer.py
+++ b/reconstruction/Dump_Buffer.py
@@ -3,17 +3,18 @@ from Buffer import Buffer
 from ..zigbee.XBee_Packet import XBee_Packet
 
 class Dump_Buffer(Buffer):
-    def __init__(self, options=None):
+    def __init__(self, settings=None):
         """
         Initialize the dump buffer object.
         """
 
-        super(Dump_Buffer, self).__init__(options)
+        super(Dump_Buffer, self).__init__(settings)
 
         # Read the data from the empty network (for calibration).
         # Note that the indices used here correspond to the fields in the
         # RSSI ground station packet (in order).
-        with open(options["calibration_file"], "r") as dump_calibration_file:
+        calibration_filename = settings.get("dump_calibration_file")
+        with open(calibration_filename, "r") as dump_calibration_file:
             data = json.load(dump_calibration_file)
 
             for packet in data["packets"]:
@@ -33,12 +34,12 @@ class Dump_Buffer(Buffer):
         # - packets: a list containing one list per packet, where each packet list
         #            contains the data from the XBee packet specification
         #            "rssi_ground_station" (in order)
-        with open(options["file"], "r") as dump_file:
+        with open(settings.get("dump_file"), "r") as dump_file:
             data = json.load(dump_file)
 
             self._number_of_sensors = data["number_of_sensors"]
-            self._origin = data["origin"]
-            self._size = data["size"]
+            self._origin = tuple(data["origin"])
+            self._size = tuple(data["size"])
 
             for packet in data["packets"]:
                 self.put(packet)

--- a/reconstruction/Reconstructor.py
+++ b/reconstruction/Reconstructor.py
@@ -1,3 +1,8 @@
+__all__ = [
+    "Least_Squares_Reconstructor", "SVD_Reconstructor",
+    "Truncated_SVD_Reconstructor"
+]
+
 class Reconstructor(object):
     def __init__(self, settings):
         """

--- a/reconstruction/Stream_Buffer.py
+++ b/reconstruction/Stream_Buffer.py
@@ -12,7 +12,6 @@ class Stream_Buffer(Buffer):
         self._origin = settings.get("stream_network_origin")
         self._size = settings.get("stream_network_size")
 
-        self._record = settings.get("stream_record")
         self._calibrate = settings.get("stream_calibrate")
 
         # Read the data from the empty network (for calibration).
@@ -37,14 +36,10 @@ class Stream_Buffer(Buffer):
         """
         Register the buffer in the XBee sensor `xbee`, and request the number
         of sensors from it.
-
-        The return value determines whether the buffer should be recorded.
         """
 
         self._number_of_sensors = xbee.number_of_sensors
         xbee.set_buffer(self)
-
-        return self._record or self._calibrate
 
     def get(self):
         """

--- a/reconstruction/Stream_Buffer.py
+++ b/reconstruction/Stream_Buffer.py
@@ -2,22 +2,26 @@ import json
 from Buffer import Buffer
 
 class Stream_Buffer(Buffer):
-    def __init__(self, options=None):
+    def __init__(self, settings=None):
         """
         Initialize the stream buffer object.
         """
 
-        super(Stream_Buffer, self).__init__(options)
+        super(Stream_Buffer, self).__init__(settings)
 
-        self._number_of_sensors = options["number_of_sensors"]
-        self._origin = options["origin"]
-        self._size = options["size"]
+        self._origin = settings.get("stream_network_origin")
+        self._size = settings.get("stream_network_size")
 
-        self._calibrate = options["calibrate"]
+        self._record = settings.get("stream_record")
+        self._calibrate = settings.get("stream_calibrate")
 
         # Read the data from the empty network (for calibration).
         if not self._calibrate:
-            with open(options["calibration_file"], "r") as stream_calibration_file:
+            calibration_filename = settings.get("stream_calibration_file")
+            if calibration_filename is None:
+                raise ValueError("If calibration mode is disabled, then a calibration file must be provided.")
+
+            with open(calibration_filename, "r") as stream_calibration_file:
                 data = json.load(stream_calibration_file)
 
                 for packet in data["packets"]:
@@ -26,8 +30,21 @@ class Stream_Buffer(Buffer):
 
                     if packet[3] and packet[6]:
                         key = (source, destination)
-                        if not key in self._calibration:
+                        if key not in self._calibration:
                             self._calibration[key] = packet[7]
+
+    def register_xbee(self, xbee):
+        """
+        Register the buffer in the XBee sensor `xbee`, and request the number
+        of sensors from it.
+
+        The return value determines whether the buffer should be recorded.
+        """
+
+        self._number_of_sensors = xbee.number_of_sensors
+        xbee.set_buffer(self)
+
+        return self._record or self._calibrate
 
     def get(self):
         """

--- a/settings/Arguments.py
+++ b/settings/Arguments.py
@@ -68,7 +68,14 @@ class Arguments(object):
         Retrieve a list of option choices from a module or a (nested) attribute.
         """
 
-        data = importlib.import_module(location[0])
+        try:
+            data = importlib.import_module(location[0])
+        except ImportError:
+            # Module is not installed. Instead of dieing, simply allow every 
+            # value. If the module is of importance outside of the setting, 
+            # then the error will be handled in a better way there.
+            return None
+
         for attr in location[1:]:
             data = getattr(data, attr)
 
@@ -161,8 +168,10 @@ class Arguments(object):
 
                 settings.set(key, value)
             except ValueError as e:
-                self.parser.print_help()
-                self.parser.exit(status=1, message=str(e))
+                # Display errors from setting the value as a usage message.
+                # This makes the error display wonky when running this in unit 
+                # tests, but the runner scripts need this for good display.
+                self.parser.error(str(e))
 
     def check_help(self):
         """

--- a/settings/Settings.py
+++ b/settings/Settings.py
@@ -161,6 +161,11 @@ class Settings(object):
         #   value to the full path. We refuse nonexistent files, but full file 
         #   names not conforming to the format are allowed.
         if data["type"] == "file" and "format" in data and value is not None:
+            if "full_name" in data:
+                full_name = data["full_name"]
+            else:
+                full_name = not required
+
             short_value, full_value = self.format_file(data["format"], value)
             if required and short_value is None:
                 raise ValueError("Setting '{}' for component '{}' must match the format '{}', value '{}' does not".format(key, self.component_name, data["format"].format("*"), value))
@@ -168,6 +173,6 @@ class Settings(object):
             if full_value is None:
                 raise ValueError("Setting '{}' for component '{}' must be given an existing file, not '{}'".format(key, self.component_name, value))
 
-            return short_value if required else full_value
+            return full_value if full_name else short_value
 
         return value

--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -60,6 +60,13 @@
                 "type": "int",
                 "min": 5,
                 "default": 20
+            },
+            "reconstruction_pause_time": {
+                "help": "Delay in seconds to wait before entering the next reconstruction loop iteration",
+                "short": "Pause time",
+                "type": "float",
+                "min": 0.0,
+                "default": 0.02
             }
         }
     },
@@ -720,42 +727,9 @@
     "reconstruction": {
         "name": "Reconstruction",
         "settings": {
-            "dataset_calibration_file": {
-                "help": "Filename part to use for dataset reconstruction calibration",
-                "type": "file",
-                "format": "assets/dataset_{}.csv",
-                "required": true,
-                "default": "empty"
-            },
-            "dataset_file": {
-                "help": "Filename part to use for dataset reconstruction",
-                "type": "file",
-                "format": "assets/dataset_{}.csv",
-                "required": true,
-                "default": "one_person_moving_square"
-            },
-            "dump_calibration_file": {
-                "help": "Filename part to use for dump reconstruction calibration",
-                "type": "file",
-                "format": "assets/dump_{}.json",
-                "required": true,
-                "default": "empty"
-            },
-            "dump_file": {
-                "help": "Filename part to use for dump reconstruction",
-                "type": "file",
-                "format": "assets/dump_{}.json",
-                "required": true,
-                "default": "static_manual"
-            },
-            "pause_time": {
-                "help": "Delay in seconds to wait before entering the next reconstruction loop iteration",
-                "type": "float",
-                "min": 0.0,
-                "default": 0.02
-            },
             "cmap": {
                 "help": "Color map for the reconstruction display. It must be a valid matplotlib colormap.",
+                "short": "Color map",
                 "type": "string",
                 "required": true,
                 "keys": ["matplotlib.cm", "datad"],
@@ -763,6 +737,7 @@
             },
             "interpolation": {
                 "help": "Pixel interpolation for the reconstruction display",
+                "short": "Interpolation",
                 "type": "string",
                 "required": false,
                 "keys": ["matplotlib.image", "AxesImage", "_interpd"],
@@ -770,9 +745,110 @@
             },
             "chunk_size": {
                 "help": "Number of measurements to obtain before rendering a new image",
+                "short": "Chunk size",
                 "type": "int",
                 "min": 1,
                 "default": 50
+            },
+            "reconstructor": {
+                "help": "Reconstruction algorithm to use",
+                "short": "Reconstructor",
+                "type": "class",
+                "module": "reconstruction.Reconstructor",
+                "replace": [" ", "_"],
+                "default": "SVD_Reconstructor"
+            }
+        }
+    },
+    "reconstruction_dataset": {
+        "name": "Reconstruction (dataset source)",
+        "parent": "reconstruction",
+        "settings": {
+            "dataset_calibration_file": {
+                "help": "Filename part to use for dataset reconstruction calibration",
+                "short": "Calibration file",
+                "type": "file",
+                "format": "assets/dataset_{}.csv",
+                "full_name": true,
+                "required": true,
+                "default": "empty"
+            },
+            "dataset_file": {
+                "help": "Filename part to use for dataset reconstruction",
+                "short": "Dataset file",
+                "type": "file",
+                "format": "assets/dataset_{}.csv",
+                "full_name": true,
+                "required": true,
+                "default": "one_person_moving_square"
+            }
+        }
+    },
+    "reconstruction_dump": {
+        "name": "Reconstruction (dump source)",
+        "parent": "reconstruction",
+        "settings": {
+            "dump_calibration_file": {
+                "help": "Filename part to use for dump reconstruction calibration",
+                "short": "Calibration file",
+                "type": "file",
+                "format": "assets/dump_{}.json",
+                "full_name": true,
+                "required": true,
+                "default": "empty"
+            },
+            "dump_file": {
+                "help": "Filename part to use for dump reconstruction",
+                "short": "Dump file",
+                "type": "file",
+                "format": "assets/dump_{}.json",
+                "full_name": true,
+                "required": true,
+                "default": "static_manual"
+            }
+        }
+    },
+    "reconstruction_stream": {
+        "name": "Reconstruction (stream source)",
+        "parent": "reconstruction",
+        "settings": {
+            "stream_network_size": {
+                "help": "The size of the network, in pixels of the resulting image",
+                "short": "Network size",
+                "type": "tuple",
+                "length": 2,
+                "subtype": "int",
+                "min": 1,
+                "default": [10, 10]
+            },
+            "stream_network_origin": {
+                "help": "The distance of the network from the origin",
+                "short": "Origin",
+                "type": "tuple",
+                "length": 2,
+                "subtype": "int",
+                "default": [0, 0]
+            },
+            "stream_record": {
+                "help": "Whether to record the received XBee packets for saving afterward",
+                "short": "Record",
+                "type": "bool",
+                "default": false
+            },
+            "stream_calibrate": {
+                "help": "Whether to assume that the current mission is a calibration. If disabled, then the calibration file is used.",
+                "short": "Calibrate mode",
+                "type": "bool",
+                "default": false
+            },
+            "stream_calibration_file": {
+                "help": "Calibration file to use for initial calibration",
+                "short": "Calibration file",
+                "type": "file",
+                "format": "assets/stream_{}.json",
+                "full_name": true,
+                "required": false,
+                "default": null
             }
         }
     },

--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -610,7 +610,7 @@
                 "short": "Algorithm",
                 "type": "class",
                 "module": "planning.Algorithm",
-                "replace": ["abcdefghijklmnopqrstuvwxyz-", "ABCDEFGHIJKLMNOPQRSTUVWXYZ_"],
+                "replace": ["-", "_"],
                 "default": "SMS_EMOA"
             },
             "discrete": {

--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -868,6 +868,7 @@
         "settings": {
             "singular_values": {
                 "help": "Number of singular values to compute",
+                "short": "Singular values",
                 "type": "int",
                 "min": 1,
                 "default": 30

--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -756,7 +756,7 @@
                 "type": "class",
                 "module": "reconstruction.Reconstructor",
                 "replace": [" ", "_"],
-                "default": "SVD_Reconstructor"
+                "default": "Truncated_SVD_Reconstructor"
             }
         }
     },
@@ -813,13 +813,13 @@
         "parent": "reconstruction",
         "settings": {
             "stream_network_size": {
-                "help": "The size of the network, in pixels of the resulting image",
+                "help": "The size of the network, in pixels of the resulting image (zero-based)",
                 "short": "Network size",
                 "type": "tuple",
                 "length": 2,
                 "subtype": "int",
                 "min": 1,
-                "default": [10, 10]
+                "default": [9, 9]
             },
             "stream_network_origin": {
                 "help": "The distance of the network from the origin",

--- a/tests/reconstruction_buffer.py
+++ b/tests/reconstruction_buffer.py
@@ -65,7 +65,7 @@ class TestReconstructionBuffer(unittest.TestCase):
         self.assertEqual(self.buffer.number_of_sensors, 0)
 
     def test_origin(self):
-        self.assertEqual(self.buffer.origin, [0, 0])
+        self.assertEqual(self.buffer.origin, (0, 0))
 
     def test_size(self):
-        self.assertEqual(self.buffer.size, [0, 0])
+        self.assertEqual(self.buffer.size, (0, 0))

--- a/tests/reconstruction_dataset_buffer.py
+++ b/tests/reconstruction_dataset_buffer.py
@@ -30,7 +30,7 @@ class TestReconstructionDatasetBuffer(SettingsTestCase):
         # Dataset buffers are regular buffers with the exception that they
         # populate the queue with XBee packets read from a CSV data file.
         # Verify that these are set correctly upon initialization.
-        # We mock the Settings.check_format method so that we can pass test 
+        # We mock the `Settings.check_format` method so that we can pass test 
         # files instead of assets to the arguments.
         arguments = Arguments("settings.json", [
             "--dataset-calibration-file", "tests/reconstruction/dataset_empty.csv",

--- a/tests/reconstruction_dump_buffer.py
+++ b/tests/reconstruction_dump_buffer.py
@@ -1,20 +1,26 @@
-import unittest
+from mock import patch
 from ..reconstruction.Dump_Buffer import Dump_Buffer
+from ..settings import Arguments, Settings
+from settings import SettingsTestCase
 
-class TestReconstructionDumpBuffer(unittest.TestCase):
-    def test_initialization(self):
+class TestReconstructionDumpBuffer(SettingsTestCase):
+    @patch.object(Settings, "check_format", wraps=lambda key, data, value: value)
+    def test_initialization(self, format_mock):
         # Dump buffers are regular buffers with the exception that they
         # populate the queue with XBee packets read from a JSON data file.
         # Verify that these are set correctly upon initialization.
-        options = {
-            "calibration_file": "tests/reconstruction/dump_empty.json",
-            "file": "tests/reconstruction/dump.json"
-        }
-        dump_buffer = Dump_Buffer(options)
+        # We mock the Settings.check_format method so that we can pass test 
+        # files instead of assets to the arguments.
+        arguments = Arguments("settings.json", [
+            "--dump-calibration-file", "tests/reconstruction/dump_empty.json",
+            "--dump-file", "tests/reconstruction/dump.json"
+        ])
+        settings = arguments.get_settings("reconstruction_dump")
+        dump_buffer = Dump_Buffer(settings)
 
         self.assertEqual(dump_buffer.number_of_sensors, 2)
-        self.assertEqual(dump_buffer.origin, [0, 0])
-        self.assertEqual(dump_buffer.size, [10, 10])
+        self.assertEqual(dump_buffer.origin, (0, 0))
+        self.assertEqual(dump_buffer.size, (10, 10))
 
         self.assertEqual(dump_buffer.count(), 2)
 

--- a/tests/reconstruction_dump_buffer.py
+++ b/tests/reconstruction_dump_buffer.py
@@ -9,7 +9,7 @@ class TestReconstructionDumpBuffer(SettingsTestCase):
         # Dump buffers are regular buffers with the exception that they
         # populate the queue with XBee packets read from a JSON data file.
         # Verify that these are set correctly upon initialization.
-        # We mock the Settings.check_format method so that we can pass test 
+        # We mock the `Settings.check_format` method so that we can pass test 
         # files instead of assets to the arguments.
         arguments = Arguments("settings.json", [
             "--dump-calibration-file", "tests/reconstruction/dump_empty.json",

--- a/tests/reconstruction_stream_buffer.py
+++ b/tests/reconstruction_stream_buffer.py
@@ -1,45 +1,69 @@
-import unittest
+from mock import MagicMock
 from ..zigbee.XBee_Packet import XBee_Packet
 from ..reconstruction.Stream_Buffer import Stream_Buffer
+from ..settings import Arguments
+from settings import SettingsTestCase
 
-class TestReconstructionStreamBuffer(unittest.TestCase):
+class TestReconstructionStreamBuffer(SettingsTestCase):
+    def setUp(self):
+        arguments = Arguments("settings.json", [
+            "--stream-network-origin", "1", "1",
+            "--stream-network-size", "15", "15",
+            "--stream-calibrate"
+        ])
+        self.settings = arguments.get_settings("reconstruction_stream")
+        self.mock_sensor = MagicMock(number_of_sensors=42)
+
+        self.packet = XBee_Packet()
+        self.packet.set("specification", "rssi_ground_station")
+        self.packet.set("sensor_id", 1)
+        self.packet.set("from_latitude", 1)
+        self.packet.set("from_longitude", 0)
+        self.packet.set("from_valid", True)
+        self.packet.set("to_latitude", 1)
+        self.packet.set("to_longitude", 10)
+        self.packet.set("to_valid", True)
+        self.packet.set("rssi", -38)
+
     def test_initialization(self):
         # Stream buffers are regular buffers with the exception that they
-        # use options to set the number of sensors, origin and size.
-        # Verify that these are set correctly upon initialization.
-        options = {
-            "number_of_sensors": 42,
-            "origin": [1, 1],
-            "size": [15, 15],
-            "calibrate": True
-        }
-        stream_buffer = Stream_Buffer(options)
+        # use settings to set the origin and size.
+        # Verify that these are set correctly upon initialization. 
+        stream_buffer = Stream_Buffer(self.settings)
 
-        self.assertEqual(stream_buffer.number_of_sensors, options["number_of_sensors"])
-        self.assertEqual(stream_buffer.origin, options["origin"])
-        self.assertEqual(stream_buffer.size, options["size"])
+        self.assertEqual(stream_buffer.number_of_sensors, 0)
+        self.assertEqual(stream_buffer.origin, (1, 1))
+        self.assertEqual(stream_buffer.size, (15, 15))
+
+    def test_initialization_without_calibration(self):
+        # When calibration mode is disabled, a calibration file for initial 
+        # calibration must be provided.
+        self.settings.set("stream_calibrate", False)
+        with self.assertRaises(ValueError):
+            stream_buffer = Stream_Buffer(self.settings)
+
+        # A full path is allowed, and dump files also work.
+        self.settings.set("stream_calibration_file", "tests/reconstruction/dump.json")
+        stream_buffer = Stream_Buffer(self.settings)
+        # The calibration initialization reads in all packets.
+        self.assertEqual(len(stream_buffer._calibration), 2)
+
+    def test_register_xbee(self):
+        # Stream buffers only know their number of sensors once an XBee is 
+        # registered. This also registers the buffer in the XBee.
+        stream_buffer = Stream_Buffer(self.settings)
+        record = stream_buffer.register_xbee(self.mock_sensor)
+
+        self.assertEqual(stream_buffer.number_of_sensors, 42)
+        self.mock_sensor.set_buffer.assert_called_once_with(stream_buffer)
+        self.assertTrue(record)
 
     def test_get(self):
-        packet = XBee_Packet()
-        packet.set("specification", "rssi_ground_station")
-        packet.set("sensor_id", 1)
-        packet.set("from_latitude", 1)
-        packet.set("from_longitude", 0)
-        packet.set("from_valid", True)
-        packet.set("to_latitude", 1)
-        packet.set("to_longitude", 10)
-        packet.set("to_valid", True)
-        packet.set("rssi", -38)
-
-        # If calibration mode is enabled, the original packet and RSSI value must be fetched.
-        options = {
-            "number_of_sensors": 42,
-            "origin": [1, 1],
-            "size": [15, 15],
-            "calibrate": True
-        }
-        stream_buffer = Stream_Buffer(options)
-        stream_buffer.put(packet)
+        # If calibration mode is enabled, the original packet and RSSI value 
+        # must be fetched.
+        stream_buffer = Stream_Buffer(self.settings)
+        stream_buffer.register_xbee(self.mock_sensor)
+        stream_buffer.put(self.packet)
 
         buffer_packet, buffer_calibrated_rssi = stream_buffer.get()
         self.assertEqual(buffer_packet.get_all(), {
@@ -55,16 +79,15 @@ class TestReconstructionStreamBuffer(unittest.TestCase):
         })
         self.assertEqual(buffer_calibrated_rssi, -38)
 
-        # If calibration mode is disabled, the original packet and calibrated RSSI values must be fetched.
-        options = {
-            "number_of_sensors": 42,
-            "origin": [1, 1],
-            "size": [15, 15],
-            "calibrate": False,
-            "calibration_file": "tests/reconstruction/stream_empty.json"
-        }
-        stream_buffer = Stream_Buffer(options)
-        stream_buffer.put(packet)
+    def test_get_with_calibration_file(self):
+        # If calibration mode is disabled, the original packet and calibrated 
+        # RSSI values must be fetched.
+        self.settings.set("stream_calibrate", False)
+        self.settings.set("stream_calibration_file",
+                          "tests/reconstruction/stream_empty.json")
+        stream_buffer = Stream_Buffer(self.settings)
+        stream_buffer.register_xbee(self.mock_sensor)
+        stream_buffer.put(self.packet)
 
         buffer_packet, buffer_calibrated_rssi = stream_buffer.get()
         self.assertEqual(buffer_packet.get_all(), {

--- a/tests/reconstruction_stream_buffer.py
+++ b/tests/reconstruction_stream_buffer.py
@@ -52,11 +52,10 @@ class TestReconstructionStreamBuffer(SettingsTestCase):
         # Stream buffers only know their number of sensors once an XBee is 
         # registered. This also registers the buffer in the XBee.
         stream_buffer = Stream_Buffer(self.settings)
-        record = stream_buffer.register_xbee(self.mock_sensor)
+        stream_buffer.register_xbee(self.mock_sensor)
 
         self.assertEqual(stream_buffer.number_of_sensors, 42)
         self.mock_sensor.set_buffer.assert_called_once_with(stream_buffer)
-        self.assertTrue(record)
 
     def test_get(self):
         # If calibration mode is enabled, the original packet and RSSI value 

--- a/tests/reconstruction_stream_buffer.py
+++ b/tests/reconstruction_stream_buffer.py
@@ -27,8 +27,8 @@ class TestReconstructionStreamBuffer(SettingsTestCase):
 
     def test_initialization(self):
         # Stream buffers are regular buffers with the exception that they
-        # use settings to set the origin and size.
-        # Verify that these are set correctly upon initialization. 
+        # use settings to set the origin and size. Verify that these are
+        # set correctly upon initialization. 
         stream_buffer = Stream_Buffer(self.settings)
 
         self.assertEqual(stream_buffer.number_of_sensors, 0)


### PR DESCRIPTION
- Create three specializations of the settings widget: the large form used in the settings view, the toolbar widget (no longer used) and a new table widget.
- Use the table widget in the planning and reconstruction views inside tabs, toolboxes and/or stacked widgets for various settings components.
- Rewrite reconstruction-based classes such as Buffers to work with settings rather than options.
- Clean up validation etc. inside settings widget, especially file widget. Handle displayed value and final value differently, also in the choices widget. Handle disallowed values better in all views using settings widgets.
- Other small cleanups and documentation 
