### PR TITLE
Reconstruction viewer: implement smoothening using percentiles

### DIFF
--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -733,7 +733,16 @@
                 "type": "string",
                 "required": true,
                 "keys": ["matplotlib.cm", "datad"],
-                "default": "RdGy"
+                "default": "gist_heat_r"
+            },
+            "percentiles": {
+                "help": "Percentiles for the reconstruction display. They are used to smoothen the image by suppressing pixel values that do not correspond to high attenuation.",
+                "short": "Percentiles",
+                "type": "list",
+                "length": 2,
+                "subtype": "int",
+                "min": 0,
+                "default": [2, 10]
             },
             "interpolation": {
                 "help": "Pixel interpolation for the reconstruction display",


### PR DESCRIPTION
This patch makes the output image much more clear as only pixel values that correspond to high attenuation are used for the image.

Futhermore we remove a finished TODO item, choose a better color map and add more comments.
