### PR TITLE
RF sensor NTP: move NTP code from XBee sensor physical to a class

### DIFF
--- a/tests/rf_sensor_ntp.py
+++ b/tests/rf_sensor_ntp.py
@@ -1,0 +1,99 @@
+import time
+import unittest
+from mock import MagicMock, patch
+from ..zigbee.RF_Sensor_NTP import RF_Sensor_NTP
+from ..zigbee.XBee_Packet import XBee_Packet
+
+class TestRFSensorNTP(unittest.TestCase):
+    def setUp(self):
+        # Mock the sensor.
+        self._sensor = MagicMock()
+        self._sensor.id = 1
+
+        self._ntp = RF_Sensor_NTP(self._sensor)
+
+    def test_start(self):
+        # Verify that the ground station packet is sent.
+        self._ntp.start()
+
+        self.assertEqual(self._sensor._send_tx_frame.call_count, 1)
+        arguments = self._sensor._send_tx_frame.call_args[0]
+
+        self.assertEqual(len(arguments), 2)
+        packet = arguments[0]
+        to = arguments[1]
+        self.assertEqual(packet.get("specification"), "ntp")
+        self.assertEqual(packet.get("sensor_id"), 1)
+        self.assertAlmostEqual(packet.get("timestamp_1"), time.time(), delta=0.1)
+        self.assertEqual(packet.get("timestamp_2"), 0)
+        self.assertEqual(packet.get("timestamp_3"), 0)
+        self.assertEqual(packet.get("timestamp_4"), 0)
+        self.assertEqual(to, 0)
+
+    @patch.object(RF_Sensor_NTP, "finish")
+    def test_process(self, mock_finish):
+        # Construct the NTP packet for the second and third timestamp.
+        packet = XBee_Packet()
+        packet.set("specification", "ntp")
+        packet.set("sensor_id", self._sensor.id)
+        packet.set("timestamp_1", 42)
+        packet.set("timestamp_2", 0)
+        packet.set("timestamp_3", 0)
+        packet.set("timestamp_4", 0)
+
+        # Verify that the second and third timestamps are set.
+        self._ntp.process(packet)
+
+        self.assertEqual(self._sensor._send_tx_frame.call_count, 1)
+        arguments = self._sensor._send_tx_frame.call_args[0]
+
+        self.assertEqual(len(arguments), 2)
+        packet = arguments[0]
+        to = arguments[1]
+        self.assertEqual(packet.get("specification"), "ntp")
+        self.assertEqual(packet.get("sensor_id"), self._sensor.id)
+        self.assertEqual(packet.get("timestamp_1"), 42)
+        self.assertAlmostEqual(packet.get("timestamp_2"), time.time(), delta=0.1)
+        self.assertAlmostEqual(packet.get("timestamp_3"), time.time(), delta=0.1)
+        self.assertEqual(packet.get("timestamp_4"), 0)
+        self.assertEqual(to, packet.get("sensor_id"))
+
+        # Construct the NTP packet for the fourth timestamp.
+        packet = XBee_Packet()
+        packet.set("specification", "ntp")
+        packet.set("sensor_id", self._sensor.id)
+        packet.set("timestamp_1", 42)
+        packet.set("timestamp_2", 43)
+        packet.set("timestamp_3", 43)
+        packet.set("timestamp_4", 0)
+
+        # Verify that the fourth timestamp is set.
+        self._ntp.process(packet)
+
+        self.assertEqual(mock_finish.call_count, 1)
+        arguments = mock_finish.call_args[0]
+
+        self.assertEqual(len(arguments), 1)
+        packet = arguments[0]
+        self.assertEqual(packet.get("specification"), "ntp")
+        self.assertEqual(packet.get("sensor_id"), self._sensor.id)
+        self.assertEqual(packet.get("timestamp_1"), 42)
+        self.assertEqual(packet.get("timestamp_2"), 43)
+        self.assertEqual(packet.get("timestamp_3"), 43)
+        self.assertAlmostEqual(packet.get("timestamp_4"), time.time(), delta=0.1)
+
+    @patch("subprocess.call")
+    def test_finish(self, mock_subprocess_call):
+        # Construct a complete NTP packet.
+        packet = XBee_Packet()
+        packet.set("specification", "ntp")
+        packet.set("sensor_id", 1)
+        packet.set("timestamp_1", 100)
+        packet.set("timestamp_2", 150)
+        packet.set("timestamp_3", 160)
+        packet.set("timestamp_4", 120)
+
+        # Verify that the clock offset is correctly calculated.
+        clock_offset = self._ntp.finish(packet)
+        self.assertEqual(clock_offset, 45)
+        self.assertEqual(mock_subprocess_call.call_count, 1)

--- a/tests/xbee_sensor_physical.py
+++ b/tests/xbee_sensor_physical.py
@@ -1,6 +1,6 @@
-import serial
-import random
 import Queue
+import random
+import serial
 import time
 from core_thread_manager import ThreadableTestCase
 from xbee import ZigBee
@@ -251,7 +251,7 @@ class TestXBeeSensorPhysical(USBManagerTestCase, ThreadableTestCase, SettingsTes
         }
         self.sensor._receive(raw_packet)
         frame_id = None
-        for key, value in self.sensor._data.iteritems():
+        for key in self.sensor._data.iterkeys():
             frame_id = key
 
         # Check if the received packet is valid.
@@ -350,19 +350,3 @@ class TestXBeeSensorPhysical(USBManagerTestCase, ThreadableTestCase, SettingsTes
         }
         self.sensor._receive(raw_packet)
         self.assertEqual(self.sensor._joined, True)
-
-    @patch("subprocess.call")
-    def test_ntp(self, mock_subprocess_call):
-        # Prepare the NTP packet.
-        packet = XBee_Packet()
-        packet.set("specification", "ntp")
-        packet.set("sensor_id", 1)
-        packet.set("timestamp_1", 100)
-        packet.set("timestamp_2", 150)
-        packet.set("timestamp_3", 160)
-        packet.set("timestamp_4", 120)
-
-        # Perform the NTP algorithm.
-        clock_offset = self.sensor._ntp(packet)
-        self.assertEqual(clock_offset, 45)
-        self.assertEqual(mock_subprocess_call.call_count, 1)

--- a/zigbee/RF_Sensor_NTP.py
+++ b/zigbee/RF_Sensor_NTP.py
@@ -1,0 +1,73 @@
+import os
+import subprocess
+import time
+from XBee_Packet import XBee_Packet
+
+class RF_Sensor_NTP(object):
+    def __init__(self, sensor):
+        """
+        Initialize the RF sensor NTP object. This object takes care
+        of performing the NTP (network time protocol) algorithm.
+        """
+
+        self._sensor = sensor
+
+    def start(self):
+        """
+        Start the NTP algorithm by sending the current time to the
+        server (ground station) for synchronization.
+        """
+
+        # Construct the NTP packet.
+        packet = XBee_Packet()
+        packet.set("specification", "ntp")
+        packet.set("sensor_id", self._sensor.id)
+        packet.set("timestamp_1", time.time())
+        packet.set("timestamp_2", 0)
+        packet.set("timestamp_3", 0)
+        packet.set("timestamp_4", 0)
+
+        # Send the NTP packet to the ground station.
+        self._sensor._send_tx_frame(packet, 0)
+
+    def process(self, packet):
+        """
+        Process an incoming NTP packet `packet`. On the server (ground
+        station) we set the second and third timestamps and send the
+        result back to the client (sensor). The client (sensor) then
+        takes care of finishing the NTP algorithm execution.
+        """
+
+        if packet.get("timestamp_2") == 0:
+            packet.set("timestamp_2", time.time())
+            packet.set("timestamp_3", time.time())
+            self._sensor._send_tx_frame(packet, packet.get("sensor_id"))
+        else:
+            packet.set("timestamp_4", time.time())
+            self.finish(packet)
+
+    def finish(self, packet):
+        """
+        Finish the NTP algorithm to synchronize the clock of the client
+        (sensor) with the clock of the server (ground station).
+
+        Refer to the original paper "Internet time synchronization: the
+        network time protocol" by David L. Mills (IEEE, 1991) for more
+        information.
+        """
+
+        # Calculate the clock offset.
+        a = packet.get("timestamp_2") - packet.get("timestamp_1")
+        b = packet.get("timestamp_3") - packet.get("timestamp_4")
+        clock_offset = float(a + b) / 2
+
+        # Apply the offset to the current clock to synchronize.
+        synchronized = time.time() + clock_offset
+
+        # Update the system clock with the synchronized clock.
+        with open(os.devnull, 'w') as FNULL:
+            subprocess.call(["date", "-s", "@{}".format(synchronized)],
+                            stdout=FNULL, stderr=FNULL)
+
+        self._sensor._synchronized = True
+        return clock_offset


### PR DESCRIPTION
Not only does this make the XBee sensor physical code smaller and more readable, but it also allows us to unit test the functionality in a more complete manner. Furthermore this change is required to avoid duplication when we implement NTP for the CC2530 sensors.
