### PR TITLE
Pylint cleanup in planning component

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -270,7 +270,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=RPi.GPIO,PyQt4.QtGui,PyQt4.QtCore
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work

--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,7 @@
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
+init-hook='import sys;sys.path.append("")'
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
@@ -16,7 +16,7 @@ persistent=yes
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=plugins.pylint_numpy,plugins.pylint_raise
 
 # Use multiple processes to speed up Pylint.
 jobs=1
@@ -60,7 +60,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating,invalid-name,relative-import,redefined-builtin,superfluous-parens,trailing-whitespace,too-few-public-methods,no-self-use,missing-docstring,too-many-public-methods,too-many-instance-attributes,protected-access,RP0401,RP0002
+disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating,invalid-name,relative-import,redefined-builtin,superfluous-parens,trailing-whitespace,too-few-public-methods,no-self-use,missing-docstring,too-many-public-methods,too-many-instance-attributes,protected-access,unused-argument,RP0401,RP0002
 
 
 [REPORTS]
@@ -189,7 +189,7 @@ max-nested-blocks=5
 max-line-length=120
 
 # Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$|raise[( ]+\w+\("[^"]*"[^"]*\)[) ]+$
 
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
@@ -304,7 +304,7 @@ callbacks=_callback
 [CLASSES]
 
 # List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,__new__,setUp,setup
+defining-attr-methods=__init__,__new__,setUp,setup,load,reset
 
 # List of valid names for the first argument in a class method.
 valid-classmethod-first-arg=cls

--- a/control/Infrared_Sensor.py
+++ b/control/Infrared_Sensor.py
@@ -40,9 +40,6 @@ class Infrared_Sensor(Threadable):
         Configure LIRC to work with the remote specified in the settings file.
         """
 
-        module = self.__class__.__module__
-        base_path = os.path.dirname(sys.modules[module].__file__)
-
         # Check if LIRC is installed.
         if not os.path.isdir("/etc/lirc"):
             raise OSError("LIRC is not installed")

--- a/control_panel/Control_Panel_Controller.py
+++ b/control_panel/Control_Panel_Controller.py
@@ -203,7 +203,7 @@ class Control_Panel_Controller(object):
             self._current_view_name = name
             view.load(self._view_data[name])
             view.show()
-        except Exception as e:
+        except:
             QtGui.QMessageBox.critical(self.central_widget, "Internal error",
                                        traceback.format_exc() + "\nThe application will now exit.")
             self.window.close()

--- a/control_panel/Control_Panel_Devices_View.py
+++ b/control_panel/Control_Panel_Devices_View.py
@@ -49,7 +49,7 @@ class Control_Panel_Devices_View(Control_Panel_View):
         # Create the header for the tree view.
         header = QtGui.QTreeWidgetItem(["Device", "Property value"])
         self._tree_view.setHeaderItem(header)
-        self._tree_view.header().setResizeMode(0, QtGui.QHeaderView.Stretch);
+        self._tree_view.header().setResizeMode(0, QtGui.QHeaderView.Stretch)
 
         # Refresh immediately to fill the tree view with the devices and to 
         # discover any vehicles that are already connected.

--- a/control_panel/Control_Panel_Loading_View.py
+++ b/control_panel/Control_Panel_Loading_View.py
@@ -36,7 +36,7 @@ class Control_Panel_Loading_View(Control_Panel_View):
 
         # Wait for insertion of the ground station XBee.
         self._xbee_insertion_delay = self._settings.get("loading_xbee_insertion_delay") * 1000
-        QtCore.QTimer.singleShot(self._xbee_insertion_delay, lambda: self._insertion_loop())
+        QtCore.QTimer.singleShot(self._xbee_insertion_delay, self._insertion_loop)
 
     def _insertion_loop(self):
         """
@@ -73,7 +73,7 @@ class Control_Panel_Loading_View(Control_Panel_View):
             self._controller.xbee.activate()
             self._controller.show_view(Control_Panel_View_Name.DEVICES)
         except KeyError:
-            QtCore.QTimer.singleShot(self._xbee_insertion_delay, lambda: self._insertion_loop())
+            QtCore.QTimer.singleShot(self._xbee_insertion_delay, self._insertion_loop)
 
     def _switch(self):
         """

--- a/control_panel/Control_Panel_Planning_View.py
+++ b/control_panel/Control_Panel_Planning_View.py
@@ -333,7 +333,7 @@ class Control_Panel_Planning_View(Control_Panel_View):
         # 0 in the algorithm population and plot object lists.
         item_index = item_index - self._overview_items
 
-        sort, indices = self._get_sort_indices()
+        indices = self._get_sort_indices()[1]
         if item_index >= len(indices):
             # Solution is not feasible or there are no results yet.
             return
@@ -369,7 +369,7 @@ class Control_Panel_Planning_View(Control_Panel_View):
         ydata = event.artist.get_ydata()
         indices = event.ind
 
-        sort, sort_indices = self._get_sort_indices()
+        sort_indices = self._get_sort_indices()[1]
         for picked_point in zip(xdata[indices], ydata[indices]):
             points = self._runner.find_objectives(picked_point)
             for i in points:
@@ -548,6 +548,6 @@ class Control_Panel_Planning_View(Control_Panel_View):
 
         t = data["iteration"]
         speed = t / float(data["cur_time"])
-        self._add_graph_data("it/second",  speed, t)
+        self._add_graph_data("it/second", speed, t)
         for key, value in data["deletions"].iteritems():
             self._add_graph_data(key, value, t)

--- a/control_panel/Control_Panel_Settings_Widgets.py
+++ b/control_panel/Control_Panel_Settings_Widgets.py
@@ -90,7 +90,8 @@ class SettingsWidget(QtGui.QWidget):
 
     def _add_parent_button(self):
         if self._settings.parent is not None:
-            parentButton = QtGui.QCommandLinkButton(self._settings.parent.name, "Go to parent ({})".format(self._settings.parent.component_name))
+            parentButton = QtGui.QCommandLinkButton(self._settings.parent.name,
+                                                    "Go to parent ({})".format(self._settings.parent.component_name))
             policy = parentButton.sizePolicy()
             policy.setVerticalPolicy(QtGui.QSizePolicy.Fixed)
             parentButton.setSizePolicy(policy)
@@ -514,7 +515,7 @@ class TextFormWidget(QLineEditValidated, FormWidget):
         text = self.text()
         validator = self.validator()
         if validator is not None:
-            state, pos = validator.validate(text, 0)
+            state = validator.validate(text, 0)[0]
             if state != QtGui.QValidator.Acceptable:
                 return self.info["value"]
 
@@ -550,7 +551,7 @@ class FileFormatValidator(QtGui.QRegExpValidator):
         try:
             self.settings.check_format(self.key, self.info, input)
             return QtGui.QValidator.Acceptable, pos
-        except ValueError as e:
+        except ValueError:
             return QtGui.QValidator.Intermediate, pos
 
 class FileFormWidget(TextFormWidget):
@@ -586,7 +587,7 @@ class FileFormWidget(TextFormWidget):
         # name to the actual file name, if necessary.
         try:
             return self.settings.check_format(self.key, self.info, text)
-        except ValueError as e:
+        except ValueError:
             return self.info["value"]
 
     def _open_file(self):
@@ -793,7 +794,7 @@ class ListFormWidget(FormWidget):
 
         self.setLayout(self._layout)
 
-        for i in range(len(self._values)):
+        for _ in range(len(self._values)):
             self._add_to_list()
 
     def _format_list(self, value):
@@ -830,7 +831,8 @@ class ListFormWidget(FormWidget):
 
         sub_info["value"] = sub_value
         sub_info["default"] = sub_default
-        sub_widget = self.form.make_value_widget(self.settings, "{}-{}".format(self.key, position), sub_info, horizontal=True)
+        sub_widget = self.form.make_value_widget(self.settings, "{}-{}".format(self.key, position),
+                                                 sub_info, horizontal=True)
 
         self._sub_widgets.append(sub_widget)
 
@@ -906,7 +908,7 @@ class ListFormWidget(FormWidget):
             self._sub_widgets[position].set_value(sub_value)
 
         # Remove item widgets not having a value anymore.
-        for index in xrange(len(value), len(self._sub_widgets)):
+        for _ in xrange(len(value), len(self._sub_widgets)):
             item = self._layout.itemAt(len(value))
             if item.layout():
                 self._remove_item(item, item.itemAt(0).widget(), item.itemAt(1).widget())
@@ -932,7 +934,8 @@ class DictFormWidget(FormWidget):
             key_text = "{} ({}):".format(key, self.form.format_type(sub_info))
             keyLabel = QtGui.QLabel(key_text)
 
-            subWidget = self.form.make_value_widget(self.settings, "{}-{}".format(self.key, key), sub_info, horizontal=True)
+            subWidget = self.form.make_value_widget(self.settings, "{}-{}".format(self.key, key),
+                                                    sub_info, horizontal=True)
             formLayout.addRow(keyLabel, subWidget)
 
             self._sub_widgets[key] = subWidget

--- a/control_panel/Control_Panel_Waypoints_View.py
+++ b/control_panel/Control_Panel_Waypoints_View.py
@@ -39,13 +39,12 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
             try:
                 waypoints = self._convert_waypoints(data["waypoints"])
                 self._import_waypoints(waypoints, from_json=False)
-            except:
+            except ValueError:
                 return
 
     def save(self):
-        waypoints, total = self._export_waypoints(repeat=False, errors=False)
         return {
-            "waypoints": waypoints
+            "waypoints": self._export_waypoints(repeat=False, errors=False)[0]
         }
 
     def show(self):
@@ -262,7 +261,7 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
         """
 
         try:
-            waypoints, total = self._export_waypoints()
+            waypoints = self._export_waypoints()[0]
         except ValueError as e:
             QtGui.QMessageBox.critical(self._controller.central_widget,
                                        "Waypoint incorrect", e.message)

--- a/control_panel/Control_Panel_Waypoints_View.py
+++ b/control_panel/Control_Panel_Waypoints_View.py
@@ -238,7 +238,7 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
 
         try:
             with open(fn, 'r') as import_file:
-                waypoints = self._convert_import(json.load(import_file))
+                waypoints = self._convert_waypoints(json.load(import_file))
         except IOError as e:
             message = "Could not open file '{}': {}".format(fn, e.strerror)
             QtGui.QMessageBox.critical(self._controller.central_widget,

--- a/core/Thread_Manager.py
+++ b/core/Thread_Manager.py
@@ -10,6 +10,7 @@ class Thread_Manager(object):
         """
 
         self._threads = {}
+        self._logger = None
 
     def register(self, name, threadable):
         """
@@ -41,7 +42,7 @@ class Thread_Manager(object):
         if sys.exc_info() != (None, None, None):
             self.log("main thread")
 
-        for name, threadable in self._threads.items():
+        for threadable in self._threads.values():
             threadable.deactivate()
 
     def interrupt(self, name):
@@ -65,7 +66,7 @@ class Thread_Manager(object):
         a custom spawned thread) in the log file.
         """
 
-        if not hasattr(self, "_logger"):
+        if self._logger is None:
             # Lazily initialize the logger.
             formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 

--- a/environment/VRMLLoader.py
+++ b/environment/VRMLLoader.py
@@ -3,8 +3,8 @@ from vrml.vrml97 import basenodes, nodetypes, parser, parseprocessor
 
 class VRMLLoader(object):
     """
-    VRML parser.
-    The VRML language is described in its specification at http://www.web3d.org/documents/specifications/14772/V2.0/index.html
+    Parser for VRML files. The VRML language is described in its specification at
+    http://www.web3d.org/documents/specifications/14772/V2.0/index.html
     """
 
     def __init__(self, environment, filename, translation=None):
@@ -49,7 +49,7 @@ class VRMLLoader(object):
                             new_transform = forward
                     else:
                         new_transform = transform
-                except NotImplemented:
+                except NotImplementedError:
                     new_transform = transform
 
                 self._parse_children(child, new_transform)
@@ -65,7 +65,6 @@ class VRMLLoader(object):
             if i == -1:
                 faces.append(face)
                 face = []
-                pass
             else:
                 point = geometry.coord.point[i]
                 if transform is not None:

--- a/geometry/Geometry.py
+++ b/geometry/Geometry.py
@@ -232,7 +232,7 @@ class Geometry(object):
         end = self.get_location_local(end)
         if start.north > end.north:
             # Swap start and end of segment
-            start,end = end,start
+            start, end = end, start
         if P.north == start.north or P.north == end.north:
             # Move point off of the line
             P = LocationLocal(P.north + self.EPSILON, P.east, P.down)
@@ -367,7 +367,7 @@ class Geometry(object):
         loc_point = LocationLocal(y, x, -z)
 
         edge_dist = self.get_distance_meters(edge[0], edge[1])
-        dists = [self.get_distance_meters(edge[i], loc_point) for i in (0,1)]
+        dists = [self.get_distance_meters(edge[i], loc_point) for i in (0, 1)]
         if max(dists) > edge_dist:
             # Point is not actually on the edge, but on the line extending from 
             # it. This edge case is possible even after skipping object 

--- a/location/Line_Follower.py
+++ b/location/Line_Follower.py
@@ -132,7 +132,6 @@ class Line_Follower(Threadable):
                 return
 
             is_line_left = (intersection == Line_Follower_Bit_Mask.LINE_LEFT)
-            is_line_right = (intersection == Line_Follower_Bit_Mask.LINE_RIGHT)
             self._callback("diverged", "left" if is_line_left else "right")
 
     def set_state(self, state):

--- a/mission/Mission_Browse.py
+++ b/mission/Mission_Browse.py
@@ -12,7 +12,7 @@ class Mission_Browse(Mission_Guided):
 
     def step(self):
         # We stand still and change the angle to look around.
-        self.send_global_velocity(0,0,0)
+        self.send_global_velocity(0, 0, 0)
         self.set_sensor_yaw(self.yaw, relative=False, direction=1)
 
         # When we're standing still, we rotate the vehicle to measure distances 

--- a/mission/Mission_Infrared.py
+++ b/mission/Mission_Infrared.py
@@ -1,3 +1,4 @@
+from ..vehicle.Robot_Vehicle import Robot_Vehicle
 from Mission_Guided import Mission_Guided
 
 class Mission_Infrared(Mission_Guided):

--- a/mission/Mission_Infrared_Grid.py
+++ b/mission/Mission_Infrared_Grid.py
@@ -31,4 +31,3 @@ class Mission_Infrared_Grid(Mission_Infrared):
 
     def _right(self):
         self._diff[1] = 1
-

--- a/mission/Mission_Pathfind.py
+++ b/mission/Mission_Pathfind.py
@@ -104,7 +104,7 @@ class Mission_Pathfind(Mission_Browse, Mission_Square):
     def check_scan(self):
         if self.sensor_dist < 2 * self.padding + self.closeness:
             print("Start scanning due to closeness.")
-            self.send_global_velocity(0,0,0)
+            self.send_global_velocity(0, 0, 0)
             self.browsing = True
             self.start_yaw = self.yaw = self.vehicle.attitude.yaw
             return True
@@ -115,5 +115,4 @@ class Mission_Pathfind(Mission_Browse, Mission_Square):
         closeness = min(self.sensor_dist - self.padding,
                         self.padding + self.closeness)
 
-        path, distance = self._astar.assign(start, goal, closeness)
-        return path
+        return self._astar.assign(start, goal, closeness)[0]

--- a/mission/Mission_Search.py
+++ b/mission/Mission_Search.py
@@ -28,6 +28,7 @@ class Mission_Search(Mission_Browse):
 
         if self.move_distance == 0:
             super(Mission_Search, self).step()
+
             if all(self.dists_done):
                 current_location = self.environment.get_location()
 
@@ -39,7 +40,6 @@ class Mission_Search(Mission_Browse):
                 right = 0
                 cycle_safe = 0
                 safeness = np.zeros(self.dists_size)
-                bounds = np.zeros(self.dists_size)
                 for d in self.dists:
                     if d == 0:
                         right = right + 1

--- a/plan_reconstruct.py
+++ b/plan_reconstruct.py
@@ -92,7 +92,6 @@ def main(argv):
     # If we have fewer nondominated solutions than the total number of 
     # individuals, then only show the nondominated ones. Otherwise, just show 
     # all feasible solutions.
-    layer = 0 if len(indices) < size else None
     c = 0
     for i in indices:
         c += 1

--- a/planning/Algorithm.py
+++ b/planning/Algorithm.py
@@ -1,8 +1,7 @@
 import numpy as np
-from collections import OrderedDict
 import itertools
 import time
-
+from collections import OrderedDict
 from ..settings import Arguments
 
 __all__ = ["NSGA", "SMS_EMOA"]

--- a/planning/Algorithm.py
+++ b/planning/Algorithm.py
@@ -2,6 +2,7 @@ import numpy as np
 import itertools
 import time
 from collections import OrderedDict
+from functools import partial
 from ..settings import Arguments
 
 __all__ = ["NSGA", "SMS_EMOA"]
@@ -75,56 +76,58 @@ class Algorithm(object):
             if self.t_current >= self.t_max:
                 break
 
-            # Select random index s of the mu points
-            s = np.random.randint(self.mu)
-            # Create a mutated point x_new from x(s) by altering each component 
-            # with a normal distributed random number generator. This is done 
-            # on each component using numpy broadcasting.
-            x_new = self.problem.mutate(P[s], self.steps)
-
-            # Evaluate objectives and constraints for x_new
-            NewFeasible, NewObjectives = self.problem.evaluate([x_new])
-            P.append(x_new)
-            Feasible.append(NewFeasible[0])
-            Objectives.append(NewObjectives[0])
-
-            # Track which points are dominated or infeasible. We track the 
-            # indices from the points list.
-            Delete = np.nonzero(np.array(Feasible) == False)[0]
-
-            # First delete the infeasible solutions, then we will care about 
-            # the nondominated solutions. This differs from the original 
-            # implementation, hopefully this is a good decision.
-            if len(Delete) > 0:
-                Deletions["infeasible"] += 1
-            else:
-                R = self.sort_nondominated(Objectives, all_layers=False)
-                Delete = list(itertools.chain(*[Rk.keys() for Rk in R[1:]]))
-                if len(Delete) > 0:
-                    Deletions["dominated"] += 1
-
-            if len(Delete) > 0:
-                # Randomly delete one of the solutions. If it is the new point, 
-                # then we do not need to do anything (we just forget it in next 
-                # iteration), otherwise we replace the deleted point with the 
-                # new point.
-                # We use numpy.random.randint to select key instead of 
-                # numpy.random.choice because of compatibility with older 
-                # Numpy.
-                idx = Delete[np.random.randint(len(Delete))]
-            else:
-                # Delete the individual with the smallest crowding distance 
-                # (NSGA) or hypervolume contribution (SMS-EMOA)
-                C = self.sort_contribution(R[0])
-
-                idx = np.argmin(C)
-                Deletions["contribution"] += 1
-
-            del P[idx]
-            del Feasible[idx]
-            del Objectives[idx]
+            self._mutate_and_select(P, Feasible, Objectives, Deletions)
 
         return P, Objectives, Feasible
+
+    def _mutate_and_select(self, P, Feasible, Objectives, Deletions):
+        # Select random index s of the mu points
+        s = np.random.randint(self.mu)
+        # Create a mutated point x_new from x(s) by altering each component 
+        # with a normal distributed random number generator. This is done on 
+        # each component using numpy broadcasting.
+        x_new = self.problem.mutate(P[s], self.steps)
+
+        # Evaluate objectives and constraints for x_new
+        NewFeasible, NewObjectives = self.problem.evaluate([x_new])
+        P.append(x_new)
+        Feasible.append(NewFeasible[0])
+        Objectives.append(NewObjectives[0])
+
+        # Track which points are dominated or infeasible. We track the indices 
+        # from the points list.
+        Delete = np.nonzero(np.logical_not(np.array(Feasible)))[0]
+
+        # First delete the infeasible solutions, then we will care about the 
+        # nondominated solutions. This differs from the original 
+        # implementation, hopefully this is a good decision.
+        if len(Delete) > 0:
+            Deletions["infeasible"] += 1
+        else:
+            R = self.sort_nondominated(Objectives, all_layers=False)
+            Delete = list(itertools.chain(*[Rk.keys() for Rk in R[1:]]))
+            if len(Delete) > 0:
+                Deletions["dominated"] += 1
+
+        if len(Delete) > 0:
+            # Randomly delete one of the solutions. If it is the new point, 
+            # then we do not need to do anything (we just forget it in next 
+            # iteration), otherwise we replace the deleted point with the new 
+            # point.
+            # We use numpy.random.randint to select key instead of 
+            # numpy.random.choice because of compatibility with older Numpy.
+            idx = Delete[np.random.randint(len(Delete))]
+        else:
+            # Delete the individual with the smallest crowding distance (NSGA) 
+            # or hypervolume contribution (SMS-EMOA)
+            C = self.sort_contribution(R[0])
+
+            idx = np.argmin(C)
+            Deletions["contribution"] += 1
+
+        del P[idx]
+        del Feasible[idx]
+        del Objectives[idx]
 
     def KLP(self, P, Objectives):
         """
@@ -202,7 +205,7 @@ class Algorithm(object):
         raise NotImplementedError("Subclasses must implement `get_name`")
 
 class NSGA(Algorithm):
-    def crowding_distance(self,Rk):
+    def crowding_distance(self, Rk):
         """
         Calculate the crowding distances of individuals for the NSGA-II
         algorithm. The individuals are nondominated and have their objective
@@ -215,14 +218,22 @@ class NSGA(Algorithm):
 
         C = np.zeros(len(Rk))
         i = 0
+
+        if len(Rk) == 0:
+            return C
+
+        keys = []
+        for obj in xrange(len(Rk.values()[0])):
+            # Sort the keys of the points according to the objective j (obj)
+            keys.append(sorted(Rk.keys(), key=partial(lambda j, i: Rk[i][j], obj)))
+
         for idx in Rk.keys():
             for j in xrange(len(Rk[idx])):
-                # Sort the keys of the points according to the objective j
-                keys = sorted(Rk.keys(), key=lambda i: Rk[i][j])
                 # Location of the index idx in the sorted keys
-                v = keys.index(idx)
-                l = Rk[keys[v-1]][j] if v > 0 else np.NINF
-                u = Rk[keys[v+1]][j] if v < len(Rk)-1 else np.inf
+                k = keys[j]
+                v = k.index(idx)
+                l = Rk[k[v-1]][j] if v > 0 else np.NINF
+                u = Rk[k[v+1]][j] if v < len(Rk)-1 else np.inf
                 C[i] += 2 * (u - l)
 
             i += 1

--- a/planning/Greedy_Assignment.py
+++ b/planning/Greedy_Assignment.py
@@ -44,6 +44,21 @@ class Greedy_Assignment(object):
         indices = np.unravel_index(np.argmin(totals), totals.shape)
         return indices, totals[indices]
 
+    def _assign_pair(self, assignment, current_positions, positions, vehicle_pair, closest_pair):
+        # Determine the synchronization (waits) between the two vehicles in the 
+        # chosen vehicle pair. There are always two permutations here.
+        syncs = itertools.permutations(self._vehicle_pairs[vehicle_pair])
+        for i, sync_pair in enumerate(syncs):
+            vehicle, other_vehicle = sync_pair
+
+            # The coordinates of the next position for the given vehicle.
+            new_position = list(positions[closest_pair, i, :])
+
+            # Create an assignment containing the full position and the other 
+            # vehicle's wait ID.
+            assignment[vehicle].append(new_position + [0, other_vehicle])
+            current_positions[vehicle-1] = new_position
+
     def assign(self, positions_pairs):
         """
         Assign the vehicles with current positions `home_positions` an ordering
@@ -69,21 +84,12 @@ class Greedy_Assignment(object):
         while len(positions) > 0:
             # The index of the distances matrix and the distance value itself.
             idx, distance = self._get_closest_pair(current_positions, positions)
+
             # The chosen vehicle pair and the chosen measurement positions pair
             vehicle_pair, closest_pair = idx
 
-            # Determine the synchronization (waits) between the two vehicles in 
-            # the chosen vehicle pair. There are always two permutations here.
-            syncs = itertools.permutations(self._vehicle_pairs[vehicle_pair])
-            for i, sync_pair in enumerate(syncs):
-                vehicle, other_vehicle = sync_pair
-
-                new_position = list(positions[closest_pair, i, :])
-
-                # Create an assignment containing the full position and the 
-                # other vehicle's wait ID.
-                assignment[vehicle].append(new_position + [0, other_vehicle])
-                current_positions[vehicle-1] = new_position
+            self._assign_pair(assignment, current_positions, positions,
+                              vehicle_pair, closest_pair)
 
             total_distance += distance
 

--- a/planning/Greedy_Assignment.py
+++ b/planning/Greedy_Assignment.py
@@ -34,7 +34,7 @@ class Greedy_Assignment(object):
                 # Given that both vehicles operate at the same time and 
                 # synchronize at the next waypoint, the time needed depends on 
                 # the longest distance that either vehicle needs to move
-                abs(current_positions[vehicle-1] - positions[:,i,:]).max(axis=1)
+                abs(current_positions[vehicle-1] - positions[:, i, :]).max(axis=1)
                 for i, vehicle in enumerate(vehicle_pair)
             ]
             for vehicle_pair in self._vehicle_pairs

--- a/planning/Problem.py
+++ b/planning/Problem.py
@@ -304,6 +304,9 @@ class Reconstruction_Plan(Problem):
         self.assigner = Greedy_Assignment(self.arguments, self.geometry)
         self.delta_rate = self.settings.get("delta_rate")
 
+        self.travel_distance = 0.0
+        self.sensor_distances = np.empty(0)
+
     def get_domain(self):
         """
         Determine the domain of each variable and the number of variables that
@@ -325,7 +328,8 @@ class Reconstruction_Plan(Problem):
         # there are variables for a single measurement so that they apply to 
         # each variable of each measurement.
         if len(steps) == self.dim/self.N:
-            return np.array(list(itertools.chain(*[[s] * self.N for s in steps]))).flatten()
+            repeated_steps = itertools.chain(*[[s] * self.N for s in steps])
+            return np.array(list(repeated_steps))
 
         return super(Reconstruction_Plan, self).format_steps(steps)
 
@@ -397,7 +401,7 @@ class Reconstruction_Plan(Problem):
             pair_diffs = positions[:, 0, :] - positions[:, 1, :]
             self.sensor_distances = np.linalg.norm(pair_diffs, axis=1)
         else:
-            self.sensor_distances = np.array([])
+            self.sensor_distances = np.empty(0)
 
         self.unsnappable = unsnappable
 
@@ -413,8 +417,8 @@ class Reconstruction_Plan(Problem):
             # If the sensor distances to waypoint distances ratio is 1, then 
             # there is no need to calculate the waypoint distance.
             if self.delta_rate < 1.0:
-                assignments, distance = self.assigner.assign(positions)
-                self.travel_distance = distance
+                distance = self.assigner.assign(positions)[1]
+                self.travel_distance = float(distance)
             else:
                 self.travel_distance = 0.0
 
@@ -553,21 +557,23 @@ class Reconstruction_Plan_Discrete(Reconstruction_Plan):
             if axis == -1:
                 continue
 
-            other_axis = (axis+1)%2
+            other_axis = (axis+1) % 2
             diff = self.size[axis]
-            if point[i+axis*self.N] + diff > self.network_size[axis]:
+            if point[i + axis*self.N] + diff > self.network_size[axis]:
                 diff = -diff
 
             s = steps[i+other_axis*self.N] * np.random.randn()
-            other_axis_point = point[i+other_axis*self.N]
-            if (
-                0 <= other_axis_point < self.padding[other_axis] or
-                self.padding[other_axis] + self.size[other_axis] < other_axis_point < self.network_size[other_axis]
-            ):
+
+            # The variable for the other axis
+            other_point = point[i + other_axis*self.N]
+            other_padding = self.padding[other_axis]
+            other_start = other_padding + self.size[other_axis]
+            other_end = self.network_size[other_axis]
+            if 0 <= other_point < other_padding or other_start < other_point < other_end:
                 s = self.size[other_axis]/2 * s
 
-            point[i+(axis+2)*self.N] = point[i+axis*self.N] + diff
-            point[i+(other_axis+2)*self.N] += s
+            point[i + (axis+2)*self.N] = point[i + axis*self.N] + diff
+            point[i + (other_axis+2)*self.N] += s
 
         return super(Reconstruction_Plan_Discrete, self).mutate(point, steps)
 

--- a/planning/Problem.py
+++ b/planning/Problem.py
@@ -394,7 +394,7 @@ class Reconstruction_Plan(Problem):
         # Set up variables used by the constraint and objective functions.
         if positions.size > 0:
             # Generate distances between all the pairs of sensor positions.
-            pair_diffs = positions[:,0,:] - positions[:,1,:]
+            pair_diffs = positions[:, 0, :] - positions[:, 1, :]
             self.sensor_distances = np.linalg.norm(pair_diffs, axis=1)
         else:
             self.sensor_distances = np.array([])
@@ -549,7 +549,7 @@ class Reconstruction_Plan_Discrete(Reconstruction_Plan):
             # a measurement snap toward the other side of the grid. This causes 
             # the points to spread out more and make it more likely that the 
             # measurement intersects with the network more.
-            axis = np.random.choice([-1,0,1])
+            axis = np.random.choice([-1, 0, 1])
             if axis == -1:
                 continue
 
@@ -562,7 +562,7 @@ class Reconstruction_Plan_Discrete(Reconstruction_Plan):
             other_axis_point = point[i+other_axis*self.N]
             if (
                 0 <= other_axis_point < self.padding[other_axis] or
-               self.padding[other_axis] + self.size[other_axis] < other_axis_point < self.network_size[other_axis]
+                self.padding[other_axis] + self.size[other_axis] < other_axis_point < self.network_size[other_axis]
             ):
                 s = self.size[other_axis]/2 * s
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,2 @@
+# Initialize as package
+__all__ = []

--- a/plugins/pylint_numpy.py
+++ b/plugins/pylint_numpy.py
@@ -1,0 +1,28 @@
+# Plugin to let pylint's AST parser know which attributes exist in numpy arrays
+# Based on https://www.logilab.org/blogentry/78354 and 
+# https://docs.pylint.org/plugins.html
+from astroid import MANAGER, nodes
+from astroid.builder import AstroidBuilder
+
+def transform(module):
+    if module.name == 'numpy':
+        fake = AstroidBuilder(manager=MANAGER).string_build('''
+import numpy
+class array(numpy.ndarray):
+    pass
+
+class recarray(numpy.ndarray):
+    pass
+''')
+
+        for name in ("array", "recarray"):
+            module.locals[name] = fake.locals[name]
+
+def register(linter):
+    """
+    Register new linter checkers and transformers
+    Called when loaded by pylint's load-plugins option.
+    We register our tranformation function here.
+    """
+
+    MANAGER.register_transform(nodes.Module, transform)

--- a/plugins/pylint_raise.py
+++ b/plugins/pylint_raise.py
@@ -1,0 +1,24 @@
+# Plugin to allow bare and broad except clauses when the body calls an 
+# interrupt handler method/function with a specific name.
+
+from functools import partial
+import astroid
+import pylint.checkers.exceptions as exceptions
+import pylint.checkers.utils as utils
+
+def is_raising(linter, body):
+    for node in body:
+        if isinstance(node, astroid.Expr) and isinstance(node.value, astroid.Call):
+            func = utils.safe_infer(node.value.func)
+            print(func.name)
+            if func.name in ("destroy", "interrupt"):
+                return True
+
+    return linter._old_is_raising(body)
+
+def register(linter):
+    if not hasattr(linter, '_old_is_raising'):
+        linter._old_is_raising = utils.is_raising
+        new_is_raising = partial(is_raising, linter)
+        exceptions.is_raising = new_is_raising
+        utils.is_raising = new_is_raising

--- a/reconstruction/Dump_Buffer.py
+++ b/reconstruction/Dump_Buffer.py
@@ -23,7 +23,7 @@ class Dump_Buffer(Buffer):
 
                 if packet[3] and packet[6]:
                     key = (source, destination)
-                    if not key in self._calibration:
+                    if key not in self._calibration:
                         self._calibration[key] = packet[7]
 
         # Read the provided dump file. The JSON file has the following structure:

--- a/reconstruction/Weight_Matrix.py
+++ b/reconstruction/Weight_Matrix.py
@@ -19,6 +19,8 @@ class Weight_Matrix(object):
         self._width, self._height = size
         self._snapper = Snap_To_Boundary(self._origin, self._width,
                                          self._height, snap_inside=snap_inside)
+        self._distances = None
+        self._matrix = None
 
         # Create a grid for the space covered by the network. This represents a pixel
         # grid that we use to determine which pixels are intersected by a link. The

--- a/tests/core_thread_manager.py
+++ b/tests/core_thread_manager.py
@@ -149,7 +149,7 @@ class TestCoreThreadManager(ThreadableTestCase):
         logger_mock = MagicMock()
         patcher = patch.object(logging, 'getLogger', Mock(return_value=logger_mock))
         patcher.start()
-        self.assertFalse(hasattr(self.thread_manager, "_logger"))
+        self.assertEqual(self.thread_manager._logger, None)
         self.thread_manager.log("'foo' source")
         self.assertEqual(self.thread_manager._logger, logger_mock)
         logger_mock.setLevel.assert_called_once_with(logging.DEBUG)

--- a/trajectory/Memory_Map.py
+++ b/trajectory/Memory_Map.py
@@ -102,9 +102,10 @@ class Memory_Map(object):
         If the index is not within the bounds of the map, this method raises
         a `KeyError`. Otherwise, the numeric value in the map is returned.
         """
-        i,j = idx
-        if self.index_in_bounds(i,j):
-            return self.map[i,j]
+
+        i, j = idx
+        if self.index_in_bounds(i, j):
+            return self.map[i, j]
 
         raise KeyError("i={} and/or j={} out of bounds ({}).".format(i, j, self.size))
 
@@ -117,9 +118,9 @@ class Memory_Map(object):
         a `KeyError`. Otherwise, the value is set within the map.
         """
 
-        i,j = idx
-        if self.index_in_bounds(i,j):
-            self.map[i,j] = value
+        i, j = idx
+        if self.index_in_bounds(i, j):
+            self.map[i, j] = value
         else:
             raise KeyError("i={} and/or j={} out of bounds ({}).".format(i, j, self.size))
 

--- a/trajectory/Monitor.py
+++ b/trajectory/Monitor.py
@@ -46,7 +46,8 @@ class Monitor(object):
         """
         Perform one step of a monitoring loop.
 
-        `add_point` can be a callback function that accepts a Location object for a detected point from the distance sensors.
+        `add_point` can be a callback function that accepts a Location object
+        for a detected point from the distance sensors.
 
         Returns `Fase` if the loop should be halted.
         """
@@ -60,8 +61,6 @@ class Monitor(object):
             print('Warning: Outside of memory map')
 
         self.mission.step()
-
-        xbee_sensor = self.environment.get_xbee_sensor()
 
         i = 0
         for sensor in self.sensors:
@@ -97,7 +96,7 @@ class Monitor(object):
         # since there is no object here.
         try:
             self.memory_map.set(vehicle_idx, 0)
-        except:
+        except KeyError:
             pass
 
         return True

--- a/trajectory/Plot.py
+++ b/trajectory/Plot.py
@@ -13,10 +13,12 @@ class Plot(object):
     """
     Plotter that can display an environment memory map.
     """
+
     def __init__(self, environment, memory_map, interactive=True):
         self.environment = environment
         self.memory_map = memory_map
         self.interactive = interactive
+        self.plt = None
         self._setup()
 
     def _create_patch(self, obj):
@@ -29,7 +31,7 @@ class Plot(object):
         return None
 
     def _setup(self):
-        # "Cheat" to see 2d map of collision data
+        # "Cheat" to see 2D map of collision data
         patches = []
         if isinstance(self.environment, Environment_Simulator):
             for obj in self.environment.get_objects():
@@ -94,7 +96,8 @@ class Plot(object):
         elif angle == 1.5*math.pi:
             angle_idx = (vehicle_idx[0], vehicle_idx[1] - arrow_length)
         else:
-            angle_idx = (vehicle_idx[0] + math.cos(angle) * arrow_length, vehicle_idx[1] + math.sin(angle) * arrow_length)
+            angle_idx = (vehicle_idx[0] + math.cos(angle) * arrow_length,
+                         vehicle_idx[1] + math.sin(angle) * arrow_length)
 
         self.arrow_options["color"] = "red"
         self.plt.annotate("", angle_idx, vehicle_idx, arrowprops=self.arrow_options)

--- a/vehicle/Vehicle.py
+++ b/vehicle/Vehicle.py
@@ -25,7 +25,12 @@ class Vehicle(Threadable):
         return module.__dict__[vehicle_class](arguments, geometry, thread_manager, usb_manager)
 
     def __init__(self, arguments, geometry, thread_manager, usb_manager):
+        """
+        Initialize the vehicle.
+        """
+
         super(Vehicle, self).__init__("vehicle", thread_manager)
+
         self._geometry = geometry
         self._home_location = None
         self._mode = VehicleMode("PLACEHOLDER")

--- a/zigbee/XBee_Configurator.py
+++ b/zigbee/XBee_Configurator.py
@@ -1,5 +1,5 @@
-from xbee import ZigBee
 import time
+from xbee import ZigBee
 from ..settings import Arguments, Settings
 
 class XBee_Configurator(object):
@@ -28,11 +28,11 @@ class XBee_Configurator(object):
         integer to a hexadecimal representation.
         """
 
-        if type(value) == int:
+        if isinstance(value, int):
             # Convert to a string, zero-fill and create the hexadecimal representation.
             value = str(value)
             value = value.zfill(len(value) + len(value) % 2).decode("hex")
-        elif type(value) != str:
+        elif not isinstance(value, str):
             raise TypeError("Unsupported type for conversion to hexadecimal.")
 
         return value

--- a/zigbee/XBee_Sensor.py
+++ b/zigbee/XBee_Sensor.py
@@ -239,7 +239,7 @@ class XBee_Sensor(Threadable):
         from_id = rssi_packet.get("sensor_id")
         from_waypoint_index = rssi_packet.get("waypoint_index")
 
-        location, waypoint_index = self._location_callback()
+        location = self._location_callback()[0]
         location_valid = self._valid_callback(other_valid=from_valid,
                                               other_id=from_id,
                                               other_index=from_waypoint_index)

--- a/zigbee/XBee_TDMA_Scheduler.py
+++ b/zigbee/XBee_TDMA_Scheduler.py
@@ -26,7 +26,7 @@ class XBee_TDMA_Scheduler(object):
 
         if self.timestamp == 0:
             self.timestamp = time.time() + ((float(self.id) / self.number_of_sensors) *
-                             self.sweep_delay)
+                                            self.sweep_delay)
         else: 
             self.timestamp += self.sweep_delay
         


### PR DESCRIPTION
- Split out large methods and other cleanups to adhere to pylint code
  style in more places, mostly the planning component here.
- Add plugins for numpy to make it understand array types better and to
  allow bare/broad except clauses if the except body calls specific
  functions, in our case the thread manager interrupt/destroy logging
  handlers.
- Ignore unused argument errors since they are often caused by inherited
  methods that do not need all the arguments.
- Allow long lines if they raise an exception with a long (formatted)
  string. This particularly happens in e.g. control panel components.
