### PR TITLE
Travis: Minor build changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,19 @@ addons:
         packages:
             - xsltproc
 before_install:
+    - export LD_LIBRARY_PATH=$HOME/lirc_install/lib:$HOME/qt_install/lib
+    - export LIBRARY_PATH=$HOME/lirc_install/lib:$HOME/qt_install/lib
+    - export CPATH=$HOME/lirc_install/include:$HOME/qt_install/include
+    - export PYTHONPATH=$PYTHONPATH:$HOME/qt_install/lib/python2.7/site-packages
     - ./travis.sh
 install:
-    - export LD_LIBRARY_PATH=$HOME/.local/lib
-    - export LIBRARY_PATH=$HOME/.local/lib
-    - export CPATH=$HOME/.local/include
     - pip install --upgrade pip
     - pip install -r requirements.txt
 cache:
     pip: true
     directories:
-        - $HOME/lirc
-        - $HOME/sip-4.18
-        - $HOME/PyQt-x11-gpl-4.11.4
+        - $HOME/lirc_install
+        - $HOME/qt_install
 script: make test
-sudo: true
 notifications:
     email: false

--- a/travis.sh
+++ b/travis.sh
@@ -1,46 +1,40 @@
 #/bin/sh
+# Script to install dependencies that are not available through pip
+# Stop on any errors
+set -e
+
+# Extract and install everything in the home directory so that the paths match
+# with those in .travis.yml
 pushd $HOME
 
 # LIRC
-if [ ! "$(ls -A lirc)" ]; then
+if [ ! "$(ls -A lirc_install)" ]; then
     git clone git://git.code.sf.net/p/lirc/git lirc
     pushd lirc
     ./autogen.sh
-    ./configure --prefix=$HOME/.local CFLAGS='-g -O2 -lrt' CXXFLAGS='-g -O2 -lrt'
-    make
-    popd
+    ./configure --prefix=$HOME/lirc_install CFLAGS='-g -O2 -lrt' CXXFLAGS='-g -O2 -lrt'
+    make systemdsystemunitdir=$HOME/lirc_systemd
+    make install systemdsystemunitdir=$HOME/lirc_systemd
 fi
 
-pushd lirc
-sudo make install
-popd
-
-# SIP
-if [ ! "$(ls -A sip-4.18)" ]; then
+if [ ! "$(ls -A qt_install)" ]; then
+    # SIP
     wget http://sourceforge.net/projects/pyqt/files/sip/sip-4.18/sip-4.18.tar.gz
     tar xzf sip-4.18.tar.gz
     pushd sip-4.18
-    python configure.py
+    python configure.py -b $HOME/qt_install/bin -d $HOME/qt_install/lib/python2.7/site-packages -e $HOME/qt_install/include --sipdir $HOME/qt_install/share/sip
     make
+    make install
     popd
-fi
 
-pushd sip-4.18
-sudo make install
-popd
-
-# PyQt4
-if [ ! "$(ls -A PyQt-x11-gpl-4.11.4)" ]; then
+    # PyQt4
     wget http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.11.4/PyQt-x11-gpl-4.11.4.tar.gz
     tar xzf PyQt-x11-gpl-4.11.4.tar.gz --keep-newer-files
     pushd PyQt-x11-gpl-4.11.4
-    python configure.py -c --confirm-license --no-designer-plugin -e QtCore -e QtGui
+    python configure.py -c --confirm-license --no-designer-plugin -e QtCore -e QtGui -d $HOME/qt_install/lib/python2.7/site-packages --sipdir $HOME/qt_install/share/sip
     make
+    make install
     popd
 fi
-
-pushd PyQt-x11-gpl-4.11.4
-sudo make install
-popd
 
 popd


### PR DESCRIPTION
Create specific install paths that can be cached and do not require sudo.
- Install lirc in a path that we can add to the cache, rather than
  adding the source and compiled partial objects to the cache. This
  should give a slight improvement when using caches (because installing
  lirc is somewhat slow) and decreases the size of the cache.
  Also install SIP and PyQt4 in such a separately cacheable path for
  sanity and cache size, affecting network latency.
- Ensure lirc does not put anything in access-protected directories.
  The same applies to SIP and PyQt4: do not place them in a protected
  virtualenv. This removes the need to run anything with sudo.

Note that the speed and cache size improvements are not that great compared to the previous configuration (>10 seconds faster and 30MB smaller cache), but it is still nice to have for sanity. Perhaps the use of the docker worker starts a little faster than the "legacy" Travis setup, but this is dependent on worker load anyway. When caches are missing the build time is still similar (8 minutes and 30 seconds).
