### PR TITLE
Fan beam mission

### DIFF
--- a/arduino/zumo_grid/zumo_grid.ino
+++ b/arduino/zumo_grid/zumo_grid.ino
@@ -9,7 +9,7 @@
 
 // SENSOR_THRESHOLD is a value to compare reflectance sensor
 // readings to to decide if the sensor is over a black line
-#define SENSOR_THRESHOLD 300
+#define SENSOR_THRESHOLD 350
 
 // ABOVE_LINE is a helper macro that takes a reflectance sensor measurement
 // and returns 1 if the sensor is over the line and 0 if otherwise

--- a/mission/Mission_Fan.py
+++ b/mission/Mission_Fan.py
@@ -1,0 +1,73 @@
+import itertools
+import math
+from collections import deque
+from dronekit import LocationLocal
+from Mission_Auto import Mission_Auto
+from ..vehicle.Robot_Vehicle import Robot_Vehicle
+
+class Mission_Fan(Mission_Auto):
+    """
+    A mission that performs almost-full fan beam measurements on a grid using
+    a `Robot_Vehicle`.
+    """
+
+    def _get_round(self):
+        rotate = int(self.size-1)/2.0
+        end = rotate
+        if self.round_number % 2 != 0:
+            rotate = math.ceil(rotate)
+
+        end = int(end)
+
+        vehicle_round = list(self.chain)[1:-end*2]
+        self.chain.rotate(int(rotate))
+        return vehicle_round
+
+    def setup(self):
+        super(Mission_Fan, self).setup()
+
+        if not isinstance(self.vehicle, Robot_Vehicle):
+            raise ValueError("Mission_Fan only works with robot vehicles")
+
+        wpzip = itertools.izip_longest
+        grid_size = int(self.size)
+        # Last coordinate index of the grid in both directions
+        size = grid_size - 1
+
+        self.chain = deque(itertools.chain(
+            wpzip(xrange(0, size), [], fillvalue=0),
+            wpzip([], xrange(0, size), fillvalue=size),
+            wpzip(xrange(size, 0, -1), [], fillvalue=size),
+            wpzip([], xrange(size, 0, -1), fillvalue=0)
+        ))
+        self.waypoints = []
+
+        location = self.vehicle.location
+        start_point = (int(location.north), int(location.east))
+
+        if location.north == 0 and location.east == 0:
+            self.id = 0
+        elif location.north == 0 and location.east == size/2:
+            self.id = 1
+        else:
+            raise ValueError("Vehicle is incorrectly positioned at ({},{}), must be at (0,0) or (0,{})".format(location.north, location.east, size/2))
+
+        last_point = None
+        last_own_point = start_point
+        self.round_number = 0
+        while last_point != (0, size/2):
+            vehicle_round = self._get_round()
+            last_point = vehicle_round[-1]
+            if self.round_number % 2 == self.id:
+                self.waypoints.extend(vehicle_round)
+                last_own_point = last_point
+            else:
+                self.waypoints.extend([last_own_point] * len(vehicle_round))
+
+            self.round_number += 1
+
+    def get_points(self):
+        self.waypoints = list(self.waypoints)
+        return [
+            LocationLocal(north, east, 0.0) for north, east in self.waypoints
+        ]

--- a/mission/Mission_Fan_Straight.py
+++ b/mission/Mission_Fan_Straight.py
@@ -3,17 +3,17 @@ from dronekit import LocationLocal
 from Mission_Auto import Mission_Auto
 from ..vehicle.Robot_Vehicle import Robot_Vehicle
 
-class Mission_Cycle(Mission_Auto):
+class Mission_Fan_Straight(Mission_Auto):
     """
     A mission that performs fan beam and straight line measurements on a grid
     using a `Robot_Vehicle`.
     """
 
     def setup(self):
-        super(Mission_Cycle, self).setup()
+        super(Mission_Fan_Straight, self).setup()
 
         if not isinstance(self.vehicle, Robot_Vehicle):
-            raise ValueError("Mission_Cycle only works with robot vehicles")
+            raise ValueError("Mission_Fan_Straight only works with robot vehicles")
 
         wpzip = itertools.izip_longest
         grid_size = int(self.size)

--- a/mission/__init__.py
+++ b/mission/__init__.py
@@ -1,6 +1,7 @@
 # We only list usable missions here, not base classes.
 __all__ = [
-    "Mission_Browse", "Mission_Calibrate", "Mission_Cycle", "Mission_Forward",
-    "Mission_Infrared", "Mission_Infrared_Grid", "Mission_Pathfind",
-    "Mission_RF_Sensor", "Mission_Search", "Mission_Square"
+    "Mission_Browse", "Mission_Calibrate", "Mission_Fan",
+    "Mission_Fan_Straight", "Mission_Forward", "Mission_Infrared",
+    "Mission_Infrared_Grid", "Mission_Pathfind", "Mission_RF_Sensor",
+    "Mission_Search", "Mission_Square"
 ]

--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -325,7 +325,7 @@
                 "help": "Mission class to use for the mission",
                 "type": "class",
                 "module": "mission",
-                "default": "Mission_Cycle"
+                "default": "Mission_Fan"
             },
             "measurement_delay": {
                 "help": "Time in seconds to wait at a waypoint to perform synchronized measurements",

--- a/tests/mission_fan.py
+++ b/tests/mission_fan.py
@@ -1,0 +1,139 @@
+import itertools
+from collections import deque
+from mock import patch
+from dronekit import LocationLocal
+from ..mission.Mission_Fan import Mission_Fan
+from ..vehicle.Mock_Vehicle import Mock_Vehicle
+from ..vehicle.Robot_Vehicle import Robot_Vehicle, Robot_State
+from environment import EnvironmentTestCase
+
+class TestMissionFan(EnvironmentTestCase):
+    def setUp(self):
+        self.register_arguments([
+            "--vehicle-class", "Robot_Vehicle_Arduino",
+            "--geometry-class", "Geometry", "--space-size", "4",
+            "--number-of-sensors", "2", "--closeness", "0",
+            "--rf-sensor-synchronization"
+        ], use_infrared_sensor=False)
+
+        super(TestMissionFan, self).setUp()
+
+        self.maxDiff = None
+
+        self.vehicle = self.environment.get_vehicle()
+
+        settings = self.arguments.get_settings("mission")
+        self.mission = Mission_Fan(self.environment, settings)
+        self.rf_sensor = self.environment.get_rf_sensor()
+        # Determine the rounds of the first vehicle, as well as the rounds in 
+        # which it waits for the other vehicle. The final point of a round is 
+        # added via the wait commands.
+        self.wait_commands = 9
+        rounds = [
+            [(1, 0), (2, 0), (3, 0), (3, 1), (3, 2), (3, 3), (2, 3), (1, 3)],
+            [(0, 3)] * (self.wait_commands + 1),
+            [(0, 2), (0, 1), (0, 0), (1, 0), (2, 0), (3, 0), (3, 1), (3, 2)],
+            [(3, 3)] * (self.wait_commands + 1),
+            [(2, 3), (1, 3), (0, 3), (0, 2), (0, 1), (0, 0), (1, 0), (2, 0)],
+            [(3, 0)] * (self.wait_commands + 1),
+            [(3, 1), (3, 2), (3, 3), (2, 3), (1, 3), (0, 3), (0, 2), (0, 1)],
+            [(0, 0)] * (self.wait_commands + 1)
+        ]
+        self.first_waypoints = list(itertools.chain(*rounds))
+
+    def test_setup_robot_vehicle(self):
+        # Check that the mission can only be run using a robot vehicle.
+        with self.assertRaises(ValueError):
+            vehicle = Mock_Vehicle(self.arguments, self.environment.geometry,
+                                   self.environment.import_manager,
+                                   self.environment.thread_manager,
+                                   self.environment.usb_manager)
+            self.mission.vehicle = vehicle
+            with patch('sys.stdout'):
+                self.mission.setup()
+
+    def test_setup_location(self):
+        # Check that the mission requires a valid starting location.
+        with self.assertRaises(ValueError):
+            self.vehicle._location = (4, 2)
+            with patch('sys.stdout'):
+                self.mission.setup()
+
+    def test_setup_init(self):
+        with patch('sys.stdout'):
+            self.mission.setup()
+
+        # Check first vehicle's state.
+        self.assertEqual(self.vehicle.location, LocationLocal(0, 0, 0))
+        self.assertEqual(self.mission.id, 0)
+        self.assertEqual(self.mission.size, 4)
+        self.assertIsInstance(self.mission.chain, deque)
+        # 4 sides, 2 rounds per side
+        self.assertEqual(self.mission.round_number, 8)
+        self.assertIsInstance(self.mission.waypoints, list)
+        waypoints = list(self.mission.waypoints)
+        self.assertEqual(waypoints, self.first_waypoints)
+
+        # Check second vehicle's state.
+        self.vehicle._location = (0, 1)
+        with patch('sys.stdout'):
+            self.mission.setup()
+
+        waypoints = list(self.mission.waypoints)
+
+        rounds = [
+            [(0, 1)] * self.wait_commands,
+            [(0, 0), (1, 0), (2, 0), (3, 0), (3, 1), (3, 2), (3, 3), (2, 3)],
+            [(1, 3)] * (self.wait_commands + 1),
+            [(0, 3), (0, 2), (0, 1), (0, 0), (1, 0), (2, 0), (3, 0), (3, 1)],
+            [(3, 2)] * (self.wait_commands + 1),
+            [(3, 3), (2, 3), (1, 3), (0, 3), (0, 2), (0, 1), (0, 0), (1, 0)],
+            [(2, 0)] * (self.wait_commands + 1),
+            [(3, 0), (3, 1), (3, 2), (3, 3), (2, 3), (1, 3), (0, 3), (0, 2)],
+            [(0, 1)]
+        ]
+        second_waypoints = list(itertools.chain(*rounds))
+
+        self.assertEqual(waypoints, second_waypoints)
+
+    @patch.object(Robot_Vehicle, "_state_loop")
+    def test_mission(self, state_loop_mock):
+        with patch('sys.stdout'):
+            self.mission.setup()
+            self.mission.arm_and_takeoff()
+            self.mission.start()
+
+        self.assertEqual(self.vehicle.mode.name, "AUTO")
+        self.assertTrue(self.vehicle.armed)
+        state_loop_mock.assert_called_once_with()
+        self.assertEqual(self.vehicle._waypoints,
+                         list(itertools.chain(*[[waypoint, None] for waypoint in self.first_waypoints])))
+        self.assertEqual(self.vehicle.get_waypoint(), None)
+
+        with patch('sys.stdout'):
+            self.mission.check_waypoint()
+
+        self.vehicle._check_state()
+        self.assertEqual(self.vehicle._state.name, "move")
+        self.assertEqual(self.vehicle._current_waypoint, 0)
+        self.assertEqual(self.vehicle.get_waypoint(), LocationLocal(1, 0, 0))
+        self.assertNotEqual(self._ttl_device.readline(), "")
+
+        self.vehicle._location = (1, 0)
+        self.vehicle._state = Robot_State("intersection")
+        with patch('sys.stdout'):
+            self.mission.check_waypoint()
+
+        # The mission waits for the other RF sensor to send a valid location packet.
+        self.vehicle._check_state()
+        self.assertEqual(self.vehicle._current_waypoint, 1)
+        self.assertEqual(self.vehicle.get_waypoint(), None)
+        self.assertTrue(self.environment.location_valid(other_valid=True, other_id=self.rf_sensor.id + 1,
+                                                        other_index=1))
+
+        with patch('sys.stdout'):
+            self.mission.check_waypoint()
+
+        self.vehicle._check_state()
+        self.assertEqual(self.vehicle._current_waypoint, 2)
+        self.assertEqual(self.vehicle.get_waypoint(), LocationLocal(2, 0, 0))

--- a/tests/mission_fan_straight.py
+++ b/tests/mission_fan_straight.py
@@ -1,12 +1,12 @@
 import itertools
 from mock import patch
 from dronekit import LocationLocal
-from ..mission.Mission_Cycle import Mission_Cycle
+from ..mission.Mission_Fan_Straight import Mission_Fan_Straight
 from ..vehicle.Mock_Vehicle import Mock_Vehicle
 from ..vehicle.Robot_Vehicle import Robot_Vehicle, Robot_State
 from environment import EnvironmentTestCase
 
-class TestMissionCycle(EnvironmentTestCase):
+class TestMissionFanStraight(EnvironmentTestCase):
     def setUp(self):
         self.register_arguments([
             "--vehicle-class", "Robot_Vehicle_Arduino",
@@ -15,12 +15,12 @@ class TestMissionCycle(EnvironmentTestCase):
             "--rf-sensor-synchronization"
         ], use_infrared_sensor=False)
 
-        super(TestMissionCycle, self).setUp()
+        super(TestMissionFanStraight, self).setUp()
 
         self.vehicle = self.environment.get_vehicle()
 
         settings = self.arguments.get_settings("mission")
-        self.mission = Mission_Cycle(self.environment, settings)
+        self.mission = Mission_Fan_Straight(self.environment, settings)
         self.rf_sensor = self.environment.get_rf_sensor()
         self.first_waypoints = [
             (1, 0), (2, 0),


### PR DESCRIPTION
- Create a mission with only fan beams, which are more complete compared to the fan beam and straight line mission (formerly known as `Mission_Cycle`).
- Test the new mission and make it the default.
- Increase Zumo grid line threshold based on experiments.
