### PR TITLE
RF sensor TDMA deadlock

### DIFF
--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -1119,6 +1119,18 @@
                 "min": 1,
                 "max": 40,
                 "default": 40
+            },
+            "shift_minimum": {
+                "help": "Minimum number of seconds to shift the schedule",
+                "type": "float",
+                "min": 0.0,
+                "default": 0.1
+            },
+            "shift_maximum": {
+                "help": "Maximum number of seconds to shift the schedule",
+                "type": "float",
+                "min": 0.0,
+                "default": 0.3
             }
         }
     },

--- a/tests/zigbee_rf_sensor.py
+++ b/tests/zigbee_rf_sensor.py
@@ -132,6 +132,7 @@ class TestZigBeeRFSensor(SettingsTestCase):
         # station packets.
         self.rf_sensor.start()
         self.assertTrue(self.rf_sensor._started)
+        self.assertEqual(self.rf_sensor._packets, [])
 
     def test_stop(self):
         # The sensor must be stopped for sending custom packets.

--- a/tests/zigbee_rf_sensor.py
+++ b/tests/zigbee_rf_sensor.py
@@ -56,7 +56,6 @@ class TestZigBeeRFSensor(SettingsTestCase):
         self.assertEqual(self.rf_sensor._connection, None)
         self.assertEqual(self.rf_sensor._buffer, None)
         self.assertIsInstance(self.rf_sensor._scheduler, TDMA_Scheduler)
-        self.assertEqual(self.rf_sensor._scheduler_next_timestamp, 0)
         self.assertEqual(self.rf_sensor._packets, [])
         self.assertIsInstance(self.rf_sensor._queue, Queue.Queue)
         self.assertEqual(self.rf_sensor._queue.qsize(), 0)
@@ -224,7 +223,7 @@ class TestZigBeeRFSensor(SettingsTestCase):
             self.rf_sensor._loop_body()
             send_custom_packets_mock.assert_called_once_with()
 
-        with patch.object(TDMA_Scheduler, "get_next_timestamp") as get_next_timestamp_mock:
+        with patch.object(TDMA_Scheduler, "update") as update_mock:
             with patch.object(RF_Sensor, "_send") as send_mock:
                 self.rf_sensor._started = True
 
@@ -232,7 +231,7 @@ class TestZigBeeRFSensor(SettingsTestCase):
                 # has been activated and started.
                 self.rf_sensor._loop_body()
 
-                get_next_timestamp_mock.assert_called_once_with()
+                update_mock.assert_called_once_with()
                 send_mock.assert_called_once_with()
 
     def test_send(self):

--- a/tests/zigbee_rf_sensor_physical.py
+++ b/tests/zigbee_rf_sensor_physical.py
@@ -121,14 +121,13 @@ class TestZigBeeRFSensorPhysical(SettingsTestCase):
             self.rf_sensor._process(packet)
 
     def test_process_rssi_broadcast_packet(self):
-        scheduler_next_timestamp = self.rf_sensor._scheduler_next_timestamp
-        packet = self.rf_sensor._create_rssi_broadcast_packet()
+        timestamp = self.rf_sensor._scheduler.timestamp
 
+        packet = self.rf_sensor._create_rssi_broadcast_packet()
         ground_station_packet = self.rf_sensor._process_rssi_broadcast_packet(packet)
 
-        # The scheduler's next timestamp must be updated.
-        self.assertNotEqual(scheduler_next_timestamp,
-                            self.rf_sensor._scheduler_next_timestamp)
+        # The scheduler's timestamp must be updated.
+        self.assertNotEqual(timestamp, self.rf_sensor._scheduler.timestamp)
 
         # A ground station packet must be returned.
         self.assertEqual(ground_station_packet.get("specification"),

--- a/tests/zigbee_rf_sensor_physical_texas_instruments.py
+++ b/tests/zigbee_rf_sensor_physical_texas_instruments.py
@@ -46,6 +46,8 @@ class TestZigBeeRFSensorPhysicalTexasInstruments(SettingsTestCase, USBManagerTes
 
         self.assertEqual(self.rf_sensor._packet_length, self.settings.get("packet_length"))
         self.assertEqual(self.rf_sensor._reset_delay, self.settings.get("reset_delay"))
+        self.assertEqual(self.rf_sensor._shift_minimum, self.settings.get("shift_minimum"))
+        self.assertEqual(self.rf_sensor._shift_maximum, self.settings.get("shift_maximum"))
 
         self.assertEqual(self.rf_sensor._pins["rx_pin"], self.settings.get("rx_pin"))
         self.assertEqual(self.rf_sensor._pins["tx_pin"], self.settings.get("tx_pin"))

--- a/tests/zigbee_rf_sensor_physical_xbee.py
+++ b/tests/zigbee_rf_sensor_physical_xbee.py
@@ -103,6 +103,11 @@ class TestZigBeeRFSensorPhysicalXBee(SettingsTestCase, USBManagerTestCase):
         self.rf_sensor._sensor.is_alive.assert_called_once_with()
         self.rf_sensor._sensor.halt.assert_called_once_with()
 
+    def test_start(self):
+        # The packet list must be an empty dictionary.
+        self.rf_sensor.start()
+        self.assertEqual(self.rf_sensor._packets, {})
+
     def test_discover(self):
         self.rf_sensor._sensor = MagicMock()
 

--- a/tests/zigbee_rf_sensor_simulator.py
+++ b/tests/zigbee_rf_sensor_simulator.py
@@ -131,7 +131,7 @@ class TestZigBeeRFSensorSimulator(SettingsTestCase):
         with self.assertRaises(TypeError):
             self.rf_sensor._receive()
 
-        scheduler_next_timestamp = self.rf_sensor._scheduler_next_timestamp
+        timestamp = self.rf_sensor._scheduler.timestamp
 
         packet = self.rf_sensor._create_rssi_broadcast_packet()
         self.rf_sensor._receive(packet=packet)
@@ -139,9 +139,8 @@ class TestZigBeeRFSensorSimulator(SettingsTestCase):
         # The receive callback must be called with the packet.
         self.receive_callback.assert_called_once_with(packet)
 
-        # The scheduler's next timestamp must be updated.
-        self.assertNotEqual(scheduler_next_timestamp,
-                            self.rf_sensor._scheduler_next_timestamp)
+        # The scheduler's timestamp must be updated.
+        self.assertNotEqual(timestamp, self.rf_sensor._scheduler.timestamp)
 
         # A ground station packet must be put in the packet list.
         self.assertEqual(len(self.rf_sensor._packets), 1)

--- a/tests/zigbee_tdma_scheduler.py
+++ b/tests/zigbee_tdma_scheduler.py
@@ -11,53 +11,65 @@ class TestZigBeeTDMAScheduler(SettingsTestCase):
         self.arguments = Arguments("settings.json", ["--number-of-sensors", "8"])
         self.settings = self.arguments.get_settings("zigbee_tdma_scheduler")
 
-        self.scheduler = TDMA_Scheduler(self.id, self.settings)
+        self.scheduler = TDMA_Scheduler(self.id, self.arguments)
 
         self.number_of_sensors = self.settings.get("number_of_sensors")
         self.sweep_delay = self.settings.get("sweep_delay")
+        self.slot_time = float(self.sweep_delay) / self.number_of_sensors
 
     def test_initialization(self):
-        # Verify that only `Settings` and `Arguments` objects can be used to initialize.
+        # Verify that only `Arguments` objects can be used to initialize.
         TDMA_Scheduler(self.id, self.arguments)
-        TDMA_Scheduler(self.id, self.settings)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
+            TDMA_Scheduler(self.id, self.settings)
+        with self.assertRaises(TypeError):
             TDMA_Scheduler(self.id, None)
 
-        # The ID of the sensor must be set.
-        self.assertEqual(self.scheduler.id, self.id)
+        # Member variables must be initialized properly.
+        self.assertEqual(self.scheduler._number_of_sensors, self.number_of_sensors)
+        self.assertEqual(self.scheduler._sweep_delay, self.sweep_delay)
 
-        # The initial timestamp must be zero for synchronization purposes.
+        self.assertEqual(self.scheduler._id, self.id)
+        self.assertEqual(self.scheduler._timestamp, 0)
+        self.assertEqual(self.scheduler._slot_time, self.slot_time)
+
+    def test_id(self):
+        # It must be possible to set and get the ID of the sensor.
+        self.scheduler.id = 1
+        self.assertEqual(self.scheduler.id, 1)
+
+    def test_timestamp(self):
+        # It must be possible to get the timestamp for sending packets.
         self.assertEqual(self.scheduler.timestamp, 0)
 
-    def test_get_next_timestamp(self):
-        # The first time the get_next_timestamp() method is called, the next
-        # timestamp is based on the current time c. If the total sweep takes t
-        # seconds, then the next timestamp is calculated as c + (i / n) * t,
-        # where i is the ID of the sensor and n is the total number of sensors
-        # in the network. This formula assures that each sensor gets an equally
-        # large time slot in the sweep.
-        calculated = self.scheduler.get_next_timestamp()
-        correct = time.time() + ((float(self.id) / self.number_of_sensors) *
-                                 self.sweep_delay)
-        self.assertAlmostEqual(calculated, correct, delta=0.1)
+    def test_update(self):
+        # The first time the method is called, the timestamp is based on the
+        # current time `c`. If the total sweep takes `t` seconds, then the
+        # timestamp is calculated as `c + (i / n) * t`, where `i` is the ID of
+        # the sensor and `n` is the total number of sensors in the network.
+        # This assures that each sensor gets an equally large time slot.
+        self.scheduler.update()
 
-        # Any subsequent calls to the get_next_timestamp() method should just
-        # increase the previous timestamp (which might have been updated in the
-        # meantime by the synchronize() method) with the sweep delay to move
-        # to the next sweep.
-        calculated = self.scheduler.get_next_timestamp()
-        correct = correct + self.sweep_delay
-        self.assertAlmostEqual(calculated, correct, delta=0.1)
+        expected = time.time() + ((float(self.id) / self.number_of_sensors) *
+                                  self.sweep_delay)
+        self.assertAlmostEqual(self.scheduler.timestamp, expected, delta=0.1)
+
+        # Any subsequent calls to the method should just increase the timestamp
+        # (which might have been updated in the meantime by the `synchronize`
+        # method) with the sweep delay to move to the next sweep.
+        self.scheduler.update()
+
+        expected += self.sweep_delay
+        self.assertAlmostEqual(self.scheduler.timestamp, expected, delta=0.1)
 
     def test_synchronize(self):
         # If the received packet is from a sensor with a lower ID than the
-        # current sensor, then the next timestamp for the current sensor should
-        # be calculated as the timestamp in the received packet plus the number
-        # of slots inbetween them. For example, if sensor 2 receives a packet from
-        # sensor 1, then sensor 2 must start sending right after sensor 1, i.e., the
-        # timestamp for sensor 2 is the timestamp of sensor 1 plus the time required
-        # for one slot, defined as the total sweep time divided by the number
-        # of sensors in the network.
+        # current sensor, then the timestamp for the current sensor must be
+        # calculated as the timestamp in the received packet plus the number
+        # of slots inbetween them. For example, if sensor 2 receives a packet
+        # from sensor 1, then sensor 2 must start sending right after sensor 1,
+        # i.e., the timestamp for sensor 2 is the timestamp of sensor 1 plus the
+        # time required for one slot.
         packet = Packet()
         packet.set("specification", "rssi_broadcast")
         packet.set("latitude", 123456789.12)
@@ -67,13 +79,13 @@ class TestZigBeeTDMAScheduler(SettingsTestCase):
         packet.set("sensor_id", 1)
         packet.set("timestamp", time.time())
 
-        calculated = self.scheduler.synchronize(packet)
-        slot_time = float(self.sweep_delay) / self.number_of_sensors
-        correct = packet.get("timestamp") + ((self.id - packet.get("sensor_id")) * slot_time)
-        self.assertEqual(calculated, correct)
+        self.scheduler.synchronize(packet)
+
+        expected = packet.get("timestamp") + ((self.id - packet.get("sensor_id")) * self.slot_time)
+        self.assertEqual(self.scheduler.timestamp, expected)
 
         # If the received packet is from a sensor with a higher ID than the
-        # current sensor, then the next timestamp for the current sensor should
+        # current sensor, then the next timestamp for the current sensor must
         # be calculated as the timestamp in the received packet plus the number
         # of slots required to complete the current sweep plus the number of slots
         # required before the current sensor is allowed to start transmitting.
@@ -82,16 +94,24 @@ class TestZigBeeTDMAScheduler(SettingsTestCase):
         # the current sweep (as we need a full slot for sensors 6, 7 and 8).
         # We then need to add 2 - 1 = 1 slot for sensor 1 and then sensor 2 is
         # allowed to start.
-        packet = Packet()
-        packet.set("specification", "rssi_broadcast")
-        packet.set("latitude", 123456789.12)
-        packet.set("longitude", 123459678.34)
-        packet.set("valid", True)
-        packet.set("waypoint_index", 2)
         packet.set("sensor_id", 6)
         packet.set("timestamp", time.time())
 
-        calculated = self.scheduler.synchronize(packet)
-        completed_round = (self.number_of_sensors - packet.get("sensor_id") + 1) * slot_time
-        correct = packet.get("timestamp") + completed_round + ((self.id - 1) * slot_time)
-        self.assertEqual(calculated, correct)
+        self.scheduler.synchronize(packet)
+
+        round_complete = (self.number_of_sensors - packet.get("sensor_id") + 1) * self.slot_time
+        expected = packet.get("timestamp") + round_complete + ((self.id - 1) * self.slot_time)
+        self.assertEqual(self.scheduler.timestamp, expected)
+
+        # Only future timestamp must be accepted.
+        packet.set("timestamp", 0)
+
+        self.scheduler.synchronize(packet)
+
+        self.assertEqual(self.scheduler.timestamp, expected)
+
+    def test_shift(self):
+        # The schedule must be shited by the provided number of seconds.
+        timestamp = self.scheduler.timestamp
+        self.scheduler.shift(0.5)
+        self.assertEqual(self.scheduler.timestamp, timestamp + 0.5)

--- a/zigbee/RF_Sensor.py
+++ b/zigbee/RF_Sensor.py
@@ -75,7 +75,6 @@ class RF_Sensor(Threadable):
         self._connection = None
         self._buffer = None
         self._scheduler = TDMA_Scheduler(self._id, arguments)
-        self._scheduler_next_timestamp = 0
         self._packets = []
         self._queue = Queue.Queue()
 
@@ -264,8 +263,8 @@ class RF_Sensor(Threadable):
         # start performing signal strength measurements.
         if not self._started:
             self._send_custom_packets()
-        elif self._id > 0 and time.time() >= self._scheduler_next_timestamp:
-            self._scheduler_next_timestamp = self._scheduler.get_next_timestamp()
+        elif self._id > 0 and time.time() >= self._scheduler.timestamp:
+            self._scheduler.update()
             self._send()
 
         time.sleep(self._loop_delay)

--- a/zigbee/RF_Sensor.py
+++ b/zigbee/RF_Sensor.py
@@ -267,8 +267,8 @@ class RF_Sensor(Threadable):
         if not self._started:
             self._send_custom_packets()
         elif self._id > 0 and time.time() >= self._scheduler.timestamp:
-            self._scheduler.update()
             self._send()
+            self._scheduler.update()
 
         time.sleep(self._loop_delay)
 

--- a/zigbee/RF_Sensor.py
+++ b/zigbee/RF_Sensor.py
@@ -182,9 +182,12 @@ class RF_Sensor(Threadable):
     def start(self):
         """
         Start the signal strength measurements (and stop sending custom packets).
+
+        Classes that inherit this base class may extend this method.
         """
 
         self._started = True
+        self._packets = []
 
     def stop(self):
         """

--- a/zigbee/RF_Sensor_Physical.py
+++ b/zigbee/RF_Sensor_Physical.py
@@ -108,7 +108,7 @@ class RF_Sensor_Physical(RF_Sensor):
         """
 
         # Synchronize the scheduler using the timestamp in the packet.
-        self._scheduler_next_timestamp = self._scheduler.synchronize(packet)
+        self._scheduler.synchronize(packet)
 
         # Create the packet for the ground station.
         return self._create_rssi_ground_station_packet(packet)

--- a/zigbee/RF_Sensor_Physical_Texas_Instruments.py
+++ b/zigbee/RF_Sensor_Physical_Texas_Instruments.py
@@ -1,4 +1,5 @@
 # Core imports
+import random
 import struct
 import time
 
@@ -45,6 +46,7 @@ class RF_Sensor_Physical_Texas_Instruments(RF_Sensor_Physical):
 
         self._address = str(self._id)
         self._joined = True
+        self._other_packet_received = False
 
         self._packet_length = self._settings.get("packet_length")
         self._reset_delay = self._settings.get("reset_delay")
@@ -146,6 +148,14 @@ class RF_Sensor_Physical_Texas_Instruments(RF_Sensor_Physical):
 
         self._receive()
 
+        # We should have received a packet from another sensor. If not, it is very
+        # likely that their schedules interfere because of their activation time.
+        # Resolve this by randomly shifting the schedule. This will be corrected
+        # automatically by the synchronization method.
+        if self._started and self._id > 0 and time.time() >= self._scheduler.timestamp:
+            if not self._other_packet_received:
+                self._scheduler.shift(random.uniform(0.05, 0.2))
+
         super(RF_Sensor_Physical_Texas_Instruments, self)._loop_body()
 
     def _send_tx_frame(self, packet, to=None):
@@ -183,6 +193,7 @@ class RF_Sensor_Physical_Texas_Instruments(RF_Sensor_Physical):
         packet = Packet()
         packet.unserialize(data)
 
+        self._other_packet_received = True
         self._process(packet, rssi=rssi)
 
     def _process(self, packet, rssi=None, **kwargs):

--- a/zigbee/RF_Sensor_Physical_Texas_Instruments.py
+++ b/zigbee/RF_Sensor_Physical_Texas_Instruments.py
@@ -154,7 +154,9 @@ class RF_Sensor_Physical_Texas_Instruments(RF_Sensor_Physical):
         # automatically by the synchronization method.
         if self._started and self._id > 0 and time.time() >= self._scheduler.timestamp:
             if not self._other_packet_received:
-                self._scheduler.shift(random.uniform(0.05, 0.2))
+                self._scheduler.shift(random.uniform(0.1, 0.3))
+                self._scheduler.update()
+                return
 
         super(RF_Sensor_Physical_Texas_Instruments, self)._loop_body()
 

--- a/zigbee/RF_Sensor_Physical_Texas_Instruments.py
+++ b/zigbee/RF_Sensor_Physical_Texas_Instruments.py
@@ -50,6 +50,8 @@ class RF_Sensor_Physical_Texas_Instruments(RF_Sensor_Physical):
 
         self._packet_length = self._settings.get("packet_length")
         self._reset_delay = self._settings.get("reset_delay")
+        self._shift_minimum = self._settings.get("shift_minimum")
+        self._shift_maximum = self._settings.get("shift_maximum")
 
         # UART connection pins for RX, TX, RTS, CTS and reset. We use board pin
         # numbering. The pins must correspond to the GPIO pins that support RXD0/TXD0 on
@@ -154,7 +156,7 @@ class RF_Sensor_Physical_Texas_Instruments(RF_Sensor_Physical):
         # automatically by the synchronization method.
         if self._started and self._id > 0 and time.time() >= self._scheduler.timestamp:
             if not self._other_packet_received:
-                self._scheduler.shift(random.uniform(0.1, 0.3))
+                self._scheduler.shift(random.uniform(self._shift_minimum, self._shift_maximum))
                 self._scheduler.update()
                 return
 

--- a/zigbee/RF_Sensor_Physical_XBee.py
+++ b/zigbee/RF_Sensor_Physical_XBee.py
@@ -96,6 +96,15 @@ class RF_Sensor_Physical_XBee(RF_Sensor_Physical):
 
         super(RF_Sensor_Physical_XBee, self).deactivate()
 
+    def start(self):
+        """
+        Start the signal strength measurements (and stop sending custom packets).
+        """
+
+        super(RF_Sensor_Physical_XBee, self).start()
+
+        self._packets = {}
+
     def discover(self, callback):
         """
         Discover all RF sensors in the network. The `callback` function is

--- a/zigbee/RF_Sensor_Simulator.py
+++ b/zigbee/RF_Sensor_Simulator.py
@@ -118,7 +118,7 @@ class RF_Sensor_Simulator(RF_Sensor):
         self._receive_callback(packet)
 
         if self._id > 0:
-            self._scheduler_next_timestamp = self._scheduler.synchronize(packet)
+            self._scheduler.synchronize(packet)
 
             # Create and complete the packet for the ground station.
             ground_station_packet = self._create_rssi_ground_station_packet(packet)


### PR DESCRIPTION
Solve some issues related to the timing and synchronization of the TDMA scheduler. This avoids some corner cases where the vehicles are unable to move, or where they flood the channel with ground station or RSSI packets.
