### PR TITLE
Waypoint ranges

### DIFF
--- a/control_panel/Control_Panel_Waypoints_View.py
+++ b/control_panel/Control_Panel_Waypoints_View.py
@@ -28,7 +28,7 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
         # and wait ID can be left out.
         self._column_defaults = (None, None, 0.0, 0, 1)
 
-        # Internal field names that can be used for indicing.
+        # Internal field names that can be used for indexing.
         fields = ["north", "east", "alt", "wait_id", "wait_count"]
         self._fields = OrderedDict(zip(fields, range(len(self._column_labels))))
 

--- a/control_panel/Control_Panel_Waypoints_View.py
+++ b/control_panel/Control_Panel_Waypoints_View.py
@@ -146,9 +146,14 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
 
         for i, col in enumerate(self._column_labels):
             if data[i] is None:
-                # If a table cell is empty, use the previous waypoint's 
-                # coordinates for the current waypoint.
-                data[i] = previous[i] if repeat else self._column_defaults[i]
+                # If a table cell is empty, then either use the previous 
+                # waypoint's coordinates for the current waypoint if `repeat` 
+                # is enabled and the column default is a value which evaluates 
+                # to `False`. Otherwise, we just use the column default.
+                if repeat and not self._column_defaults[i]:
+                    data[i] = previous[i]
+                else:
+                    data[i] = self._column_defaults[i]
             else:
                 try:
                     data[i] = self._cast_cell(i, data[i])

--- a/control_panel/Control_Panel_Waypoints_Widgets.py
+++ b/control_panel/Control_Panel_Waypoints_Widgets.py
@@ -25,6 +25,32 @@ class WaypointsTableWidget(QtGui.QTableWidget):
         verticalHeader.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         verticalHeader.customContextMenuRequested.connect(self._make_menu)
 
+    def get_row_data(self, row):
+        """
+        Retrieve the cell data from the given row number `row`.
+
+        The cell data is returned as a list, where each value is either `None`,
+        indicating that the cell was not filled, a boolean for cells with
+        a check role, or the string value for other cells.
+
+        Additionally, a boolean is returned indicating whether the row was
+        completely empty, i.e., not filled or altered.
+        """
+
+        empty = True
+        data = []
+        for col in range(len(self._column_defaults)):
+            item = self.item(row, col)
+            # Handle unaltered column cells (no item widget) and empty columns 
+            # (text contents equals to empty string)
+            if item is None or item.text() == "":
+                data.append(None)
+            else:
+                data.append(item.text())
+                empty = False
+
+        return data, empty
+
     def removeRows(self):
         """
         Remove all the rows in the table.

--- a/geometry/Geometry.py
+++ b/geometry/Geometry.py
@@ -5,10 +5,10 @@ from dronekit import Locations, LocationLocal
 
 class Geometry(object):
     """
-    Geometry utility functions
+    Geometry utility methods.
 
-    This is a class with functions that calculate distances, locations or 
-    angles based on specific input.
+    This is a class with methods that calculate distances, locations or angles
+    based on specific input.
 
     Note that some methods assume certain properties of the earth's surface, 
     such as it being spherical or being flat. Depending on these assumptions, 
@@ -16,7 +16,13 @@ class Geometry(object):
     subclasses make different assumptions about the geometry.
     Note that (`y`,`x`) = (`lat`,`lon`) = (`N`,`E`).
 
-    The base class does uses meters as the base unit for coordinates.
+    The base class does uses meters as the base unit for coordinates, and works
+    only with `LocationLocal` objects and the local frame of `Locations` objects
+    from the `dronekit` library. The third coordinate in `LocationLocal` is
+    calculated downward from the origin altitude, although in some methods we
+    convert this to an upward altitude coordinate for consistency with the two
+    other location objects.
+
     Use `Geometry_Spherical` for geographic coordinates on a spherical earth.
     """
 
@@ -55,7 +61,7 @@ class Geometry(object):
 
         return location1, location2
 
-    def make_location(self, lat, lon, alt):
+    def make_location(self, lat, lon, alt=0):
         """
         Create a location object based on user-specified coordinates `lat`,
         `lon` and `alt`. These may or may not actually correspond to the
@@ -68,6 +74,16 @@ class Geometry(object):
         """
 
         return LocationLocal(lat, lon, -alt)
+
+    def get_coordinates(self, location):
+        """
+        Retrieve the coordinates from the given `location`.
+
+        The location's coordinates are returned as a tuple.
+        """
+
+        location = self.get_location_local(location)
+        return location.north, location.east, -location.down
 
     def bearing_to_angle(self, bearing):
         """

--- a/geometry/Geometry.py
+++ b/geometry/Geometry.py
@@ -46,12 +46,14 @@ class Geometry(object):
 
     def equalize(self, location1, location2):
         """
-        Ensure that two location objects are of the same class.
+        Ensure that the two `Location` objects `location1` and `location2` are
+        of the same class.
 
-        The base class only accepts `LocationLocal` objects.
-        Extending classes can support `LocationGlobal` and
-        `LocationGlobalRelative` classes and use this method to ensure that two
-        objects are comparable.
+        The base class only accepts `LocationLocal` and `Locations` objects.
+        Other types cause this method to raise a `TypeError`. Extending classes
+        can support `LocationGlobal` and `LocationGlobalRelative` classes.
+
+        Use this method to ensure that two objects are comparable.
 
         Returns the converted location objects.
         """
@@ -60,6 +62,22 @@ class Geometry(object):
         location2 = self.get_location_local(location2)
 
         return location1, location2
+
+    def equals(self, location1, location2):
+        """
+        Check whether the two `Location` objects `location1` and `location2`
+        describe the same location.
+
+        If the two objects cannot be cast to comparable types, then this method
+        raises a `TypeError`. Otherwise, it returns a boolean whether the
+        locations have the same coordinates.
+        """
+
+        location1, location2 = self.equalize(location1, location2)
+        if self.get_coordinates(location1) == self.get_coordinates(location2):
+            return True
+
+        return False
 
     def make_location(self, lat, lon, alt=0.0):
         """

--- a/geometry/Geometry.py
+++ b/geometry/Geometry.py
@@ -16,7 +16,7 @@ class Geometry(object):
     subclasses make different assumptions about the geometry.
     Note that (`y`,`x`) = (`lat`,`lon`) = (`N`,`E`).
 
-    The base class does uses meters as the base unit for coordinates, and works
+    The base class does use meters as the base unit for coordinates, and works
     only with `LocationLocal` objects and the local frame of `Locations` objects
     from the `dronekit` library. The third coordinate in `LocationLocal` is
     calculated downward from the origin altitude, although in some methods we
@@ -74,17 +74,14 @@ class Geometry(object):
         """
 
         location1, location2 = self.equalize(location1, location2)
-        if self.get_coordinates(location1) == self.get_coordinates(location2):
-            return True
-
-        return False
+        return self.get_coordinates(location1) == self.get_coordinates(location2)
 
     def make_location(self, lat, lon, alt=0.0):
         """
         Create a location object based on user-specified coordinates `lat`,
         `lon` and `alt`. These may or may not actually correspond to the
         latitude, longitude and altitude coordinates, but to some similar
-        geometric coordinate system reference frame. The return location
+        geometric coordinate system reference frame. The returned location
         object is most appropriate to this geometry.
 
         This should only be used if we want to have a location that is valid
@@ -536,7 +533,7 @@ class Geometry(object):
 
         return abs(dot) > self.EPSILON
 
-    def get_intersection(self, face, cp, location, u, dot):
+    def _get_intersection(self, face, cp, location, u, dot):
         """
         Finish calculating the intersection point of a line `u` from a given
         `location` and a plane `face`.
@@ -643,8 +640,8 @@ class Geometry(object):
             return (None, None)
 
         # Calculate the intersection point
-        factor, loc_point = self.get_intersection(face, cp, location1, u,
-                                                  nu_dot)
+        factor, loc_point = self._get_intersection(face, cp, location1, u,
+                                                   nu_dot)
 
         if not self.point_inside_plane(face, cp, loc_point, verbose=verbose):
             # The intersection point is not actually inside the polygon, but 

--- a/geometry/Geometry.py
+++ b/geometry/Geometry.py
@@ -61,7 +61,7 @@ class Geometry(object):
 
         return location1, location2
 
-    def make_location(self, lat, lon, alt=0):
+    def make_location(self, lat, lon, alt=0.0):
         """
         Create a location object based on user-specified coordinates `lat`,
         `lon` and `alt`. These may or may not actually correspond to the

--- a/geometry/Geometry_Grid.py
+++ b/geometry/Geometry_Grid.py
@@ -12,6 +12,12 @@ class Geometry_Grid(Geometry):
         diff = self._diff_location(location1, location2)
         return abs(diff.north) + abs(diff.east) + abs(diff.down)
 
+    def _get_range(self, start_coord, end_coord, count):
+        R = super(Geometry_Grid, self)._get_range(start_coord, end_coord, count)
+
+        # Ensure the range contains only grid coordinates
+        return np.round(R)
+
     def get_neighbor_offsets(self):
         # pylint: disable=bad-continuation,bad-whitespace
         return np.array([          (-1, 0),

--- a/geometry/Geometry_Spherical.py
+++ b/geometry/Geometry_Spherical.py
@@ -24,6 +24,12 @@ class Geometry_Spherical(Geometry):
         else:
             raise TypeError("Home location must be global for spherical geometry, got: {}".format(home_location))
 
+    def get_location_frame(self, location):
+        if not isinstance(location, Locations):
+            raise TypeError("`location` must be a `Locations` object")
+
+        return location.global_relative_frame
+
     def get_locations_frame(self, location1, location2):
         """
         Retrieve the location frame from a `Locations` object `location1` that
@@ -32,10 +38,10 @@ class Geometry_Spherical(Geometry):
 
         if isinstance(location2, LocationLocal):
             return location1.local_frame
-        elif isinstance(location2, LocationGlobal):
+        if isinstance(location2, LocationGlobal):
             return location1.global_frame
-        else:
-            return location1.global_relative_frame
+
+        return location1.global_relative_frame
 
     def equalize(self, location1, location2):
         if isinstance(location1, Locations):
@@ -65,6 +71,9 @@ class Geometry_Spherical(Geometry):
                                        location2.alt + alt)
 
         return location1, location2
+
+    def make_location(self, lat, lon, alt):
+        return LocationGlobalRelative(lat, lon, alt)
 
     def get_location_local(self, location):
         if isinstance(location, LocationLocal):

--- a/geometry/Geometry_Spherical.py
+++ b/geometry/Geometry_Spherical.py
@@ -95,7 +95,7 @@ class Geometry_Spherical(Geometry):
 
         return location1, location2
 
-    def make_location(self, lat, lon, alt=0):
+    def make_location(self, lat, lon, alt=0.0):
         return LocationGlobalRelative(lat, lon, alt)
 
     def get_coordinates(self, location):

--- a/mission/Mission.py
+++ b/mission/Mission.py
@@ -1,9 +1,8 @@
 import math
 import sys
 import time
-from dronekit import LocationGlobal, VehicleMode
+from dronekit import VehicleMode
 from ..trajectory.Memory_Map import Memory_Map
-from ..geometry.Geometry_Spherical import Geometry_Spherical
 
 class Mission(object):
     """
@@ -128,8 +127,12 @@ class Mission(object):
         home_location = self.vehicle.home_location
         if home_location is not None:
             print("Home location: {}".format(home_location))
-            if isinstance(home_location, LocationGlobal) and isinstance(self.geometry, Geometry_Spherical):
+            try:
                 self.geometry.set_home_location(home_location)
+            except TypeError:
+                # The geometry does not accept the home location type, so let's 
+                # not provide a new home location at all.
+                pass
 
     def get_waypoints(self):
         """

--- a/mission/Mission_Auto.py
+++ b/mission/Mission_Auto.py
@@ -1,7 +1,6 @@
 import time
-from dronekit import LocationLocal, LocationGlobalRelative, VehicleMode
+from dronekit import LocationLocal, VehicleMode
 from Mission import Mission
-from ..geometry.Geometry_Spherical import Geometry_Spherical
 
 class Mission_Auto(Mission):
     """
@@ -61,10 +60,7 @@ class Mission_Auto(Mission):
             return LocationLocal(point.north, point.east, down)
 
         alt = point.alt if point.alt != 0.0 else self.altitude
-        if isinstance(self.geometry, Geometry_Spherical):
-            return LocationGlobalRelative(point.lat, point.lon, alt)
-
-        return LocationLocal(point.lat, point.lon, -alt)
+        return self.geometry.make_location(point.lat, point.lon, alt)
 
     def add_waypoint(self, point, required_sensors=None):
         """

--- a/mission/Mission_Auto.py
+++ b/mission/Mission_Auto.py
@@ -17,7 +17,11 @@ class Mission_Auto(Mission):
         self._required_waypoint_sensors = []
 
     def arm_and_takeoff(self):
-        self.add_commands()
+        try:
+            self.add_commands()
+        except RuntimeError:
+            pass
+
         super(Mission_Auto, self).arm_and_takeoff()
 
     def get_waypoints(self):

--- a/mission/Mission_RF_Sensor.py
+++ b/mission/Mission_RF_Sensor.py
@@ -56,7 +56,7 @@ class Mission_RF_Sensor(Mission_Auto):
 
     def add_commands(self):
         # Commands are added when they arrive, not in here.
-        pass
+        raise RuntimeError("RF sensor mission does not add commands")
 
     def _send_ack(self):
         """

--- a/tests/geometry.py
+++ b/tests/geometry.py
@@ -247,6 +247,12 @@ class TestGeometry(LocationTestCase):
                 "end": (3.0, 4.0),
                 "count": 5,
                 "range": [(3.0, 4.0)]*5
+            },
+            {
+                "start": (4.0, 5.0),
+                "end": (6.0, 7.0),
+                "count": 1,
+                "range": [(6.0, 7.0)]
             }
         ]
         for case in cases:
@@ -256,9 +262,9 @@ class TestGeometry(LocationTestCase):
                                                       count=case["count"])
             self.assertEqual(len(actual), len(case["range"]))
             for actual_loc, p in zip(actual, case["range"]):
-                expected_loc = LocationLocal(p[0], p[1],
-                                             -p[2] if len(p) > 2 else 0.0)
-                self.assertEqual(actual_loc, expected_loc)
+                expected_loc = self.geometry.get_location_meters(home, *p)
+                self.assertEqual(actual_loc,
+                                 self.geometry.get_location_local(expected_loc))
 
     def test_get_location_angle(self):
         loc = LocationLocal(5.0, 3.0, -1.0)

--- a/tests/geometry.py
+++ b/tests/geometry.py
@@ -135,6 +135,13 @@ class TestGeometry(LocationTestCase):
         with self.assertRaises(TypeError):
             self.geometry.equalize(self.global_location, self.local_location)
 
+    def test_equals(self):
+        loc = LocationLocal(1.0, 2.0, -3.0)
+        self.assertTrue(self.geometry.equals(loc, loc))
+        # Integer coordinates are still equal to floats.
+        self.assertTrue(self.geometry.equals(loc, LocationLocal(1.0, 2, -3.0)))
+        self.assertFalse(self.geometry.equals(loc, LocationLocal(1, 2, -3.14)))
+
     def test_make_location(self):
         # Base geometry creates local locations with inverted down component.
         loc = LocationLocal(1.0, 2.0, -3.0)

--- a/tests/geometry.py
+++ b/tests/geometry.py
@@ -11,6 +11,7 @@ import numpy as np
 from dronekit import LocationGlobal, LocationGlobalRelative, LocationLocal, Locations
 
 # Package imports
+from ..bench.Method_Coverage import covers
 from ..geometry.Geometry import Geometry
 
 class LocationTestCase(unittest.TestCase):
@@ -120,7 +121,7 @@ class TestGeometry(LocationTestCase):
             self.geometry.set_home_location(self.global_location)
 
     def test_equalize(self):
-        # Local locations are kept intanct.
+        # Local locations are kept intact.
         loc1 = LocationLocal(1.0, 2.0, 3.0)
         loc2 = LocationLocal(4.5, 6.7, -8.9)
         new_loc1, new_loc2 = self.geometry.equalize(loc1, loc2)
@@ -219,7 +220,7 @@ class TestGeometry(LocationTestCase):
         self.assertAlmostEqual(self.geometry.get_distance_meters(loc, loc2),
                                5.0, delta=self.dist_delta)
 
-    def test_diff_location(self):
+    def test_diff_location_meters(self):
         loc = LocationLocal(5.4, 3.2, -1.0)
         # 3 * 3 + 4 * 4 = 9 + 16 = 25 which is 5 squared.
         loc2 = self.geometry.get_location_meters(loc, 3.0, 4.0, 5.0)
@@ -411,6 +412,18 @@ class TestGeometry(LocationTestCase):
         self.assertEqual(edges[1], (locations[1], locations[2]))
         self.assertEqual(edges[2], (locations[2], locations[0]))
 
+    def test_get_projected_location(self):
+        location = LocationLocal(1.0, 2.0, -3.0)
+        self.assertEqual(self.geometry.get_projected_location(location, 0),
+                         LocationLocal(2.0, 3.0, 0.0))
+        self.assertEqual(self.geometry.get_projected_location(location, 1),
+                         LocationLocal(1.0, 3.0, 0.0))
+        self.assertEqual(self.geometry.get_projected_location(location, 2),
+                         location)
+
+    @covers([
+        "get_plane_intersection", "get_plane_vector", "point_inside_plane"
+    ])
     def test_get_plane_distance(self):
         home = self._make_relative_location(0.0, 0.0, 0.0)
         cases = [

--- a/tests/geometry.py
+++ b/tests/geometry.py
@@ -16,27 +16,46 @@ from ..geometry.Geometry_Grid import Geometry_Grid
 from ..geometry.Geometry_Spherical import Geometry_Spherical
 
 class LocationTestCase(unittest.TestCase):
+    """
+    Test case base class that provides equality checking for `Location` objects.
+
+    This makes it possible to use `assertEqual` and related unit test methods
+    on location objects of the same type.
+    """
+
     def setUp(self):
         super(LocationTestCase, self).setUp()
         self.addTypeEqualityFunc(LocationLocal, self.assertLocationLocalEqual)
-        self.addTypeEqualityFunc(LocationGlobal, self.assertLocationGlobalEqual)
-        self.addTypeEqualityFunc(LocationGlobalRelative, self.assertLocationGlobalEqual)
+        for loc_type in (LocationGlobal, LocationGlobalRelative):
+            self.addTypeEqualityFunc(loc_type, self.assertLocationGlobalEqual)
 
-    def assertLocationLocalEqual(self, loc1, loc2, msg=None):
-        if loc1.north != loc2.north or loc1.east != loc2.east or loc1.down != loc2.down:
+    def assertLocationLocalEqual(self, first_loc, second_loc, msg=None):
+        first_coords = (first_loc.north, first_loc.east, first_loc.down)
+        second_coords = (second_loc.north, second_loc.east, second_loc.down)
+        if first_coords != second_coords:
             if msg is None:
                 msg = ""
-            msg += "{} != {}".format(loc1, loc2)
+            msg += "{} != {}".format(first_loc, second_loc)
             raise self.failureException(msg)
 
-    def assertLocationGlobalEqual(self, loc1, loc2, msg=None):
-        if loc1.lat != loc2.lat or loc1.lon != loc2.lon or loc1.alt != loc2.alt:
+    def assertLocationGlobalEqual(self, first_loc, second_loc, msg=None):
+        first_coords = (first_loc.lat, first_loc.lon, first_loc.alt)
+        second_coords = (second_loc.lat, second_loc.lon, second_loc.alt)
+        if first_coords != second_coords:
             if msg is None:
                 msg = ""
-            msg += "{} != {}".format(loc1, loc2)
+            msg += "{} != {}".format(first_loc, second_loc)
             raise self.failureException(msg)
 
 class TestGeometry(LocationTestCase):
+    """
+    Geometry test class.
+
+    This class tests the `Geometry` interface. It can be subclassed in order
+    to test the subclasses of `Geometry`. The test methods are then inherited,
+    so some may need to be overridden to test different behavior.
+    """
+
     def setUp(self):
         super(TestGeometry, self).setUp()
         self.geometry = Geometry()
@@ -45,90 +64,150 @@ class TestGeometry(LocationTestCase):
         self.coord_delta = self.dist_delta
         self.angle_delta = sys.float_info.epsilon * 10
 
+        # Create a mock version of a `Locations` object. The location frames 
+        # have property mocks that can be configured to return a specific 
+        # location value.
+        self.locations_mock = Mock(spec_set=Locations)
+        self.relative_mock = PropertyMock()
+        self.global_mock = PropertyMock()
+        self.local_mock = PropertyMock()
+
+        type(self.locations_mock).global_relative_frame = self.relative_mock
+        type(self.locations_mock).global_frame = self.global_mock
+        type(self.locations_mock).local_frame = self.local_mock
+
+        # Location objects that can be used by type checking tests, where the 
+        # coordinate values do not matter at all.
+        self.local_location = LocationLocal(1.0, 2.0, 3.0)
+        self.global_location = LocationGlobal(4.0, 5.0, 6.0)
+        self.relative_location = LocationGlobalRelative(7.0, 8.0, 9.0)
+
     def _make_global_location(self, x, y, z=0.0):
+        """
+        Create a `Location` object that is suitable as a global location.
+
+        The returned type depends on the geometry being tested.
+        """
+
         return LocationLocal(x, y, -z)
 
     def _make_relative_location(self, x, y, z=0.0):
+        """
+        Create a `Location` object that is suitable as a relative location.
+
+        The returned type depends on the geometry being tested.
+        """
+
         return LocationLocal(x, y, -z)
 
-    def test_home_location_type(self):
+    def test_set_home_location(self):
+        self.assertEqual(self.geometry.home_location,
+                         self._make_global_location(0.0, 0.0, 0.0))
+
+        home_loc = self._make_global_location(1.0, 2.0, 3.0)
+        self.geometry.set_home_location(home_loc)
+        self.assertEqual(self.geometry.home_location, home_loc)
+
+    def test_set_home_location_type(self):
+        # Base geometry does not support relative or global locations.
         with self.assertRaises(TypeError):
-            self.geometry.set_home_location(LocationGlobalRelative(3.0, 2.0, 1.0))
+            self.geometry.set_home_location(self.relative_location)
 
         with self.assertRaises(TypeError):
-            self.geometry.set_home_location(LocationGlobal(3.0, 2.0, 1.0))
-
-    def test_home_location(self):
-        self.assertEqual(self.geometry.home_location, self._make_global_location(0.0, 0.0, 0.0))
-        self.geometry.set_home_location(self._make_global_location(1.0, 2.0, 3.0))
-        self.assertEqual(self.geometry.home_location, self._make_global_location(1.0, 2.0, 3.0))
+            self.geometry.set_home_location(self.global_location)
 
     def test_equalize(self):
-        loc1 = LocationLocal(1.0, 2.0, -3.0)
-        loc2 = LocationGlobalRelative(5.4, 6.7, 8.0)
-        loc3 = LocationGlobal(54.7, 10.2, 1000.8)
+        # Local locations are kept intanct.
+        loc1 = LocationLocal(1.0, 2.0, 3.0)
+        loc2 = LocationLocal(4.5, 6.7, -8.9)
+        new_loc1, new_loc2 = self.geometry.equalize(loc1, loc2)
+        self.assertEqual(loc1, new_loc1)
+        self.assertEqual(loc2, new_loc2)
+
+        # Base geometry does not support relative or global locations.
         with self.assertRaises(TypeError):
-            self.geometry.equalize(loc1, loc2)
+            self.geometry.equalize(self.local_location, self.relative_location)
         with self.assertRaises(TypeError):
-            self.geometry.equalize(loc2, loc3)
+            self.geometry.equalize(self.relative_location, self.global_location)
         with self.assertRaises(TypeError):
-            self.geometry.equalize(loc3, loc1)
+            self.geometry.equalize(self.global_location, self.local_location)
 
     def test_make_location(self):
+        # Base geometry creates local locations with inverted down component.
         loc = LocationLocal(1.0, 2.0, -3.0)
         self.assertEqual(self.geometry.make_location(1.0, 2.0, 3.0), loc)
 
+    def test_get_coordinates(self):
+        # Check that retrieving coordinates from `Location` objects works.
+        # The supported location types of the geometry are tested.
+        loc1 = LocationLocal(1.0, 2.0, -3.0)
+        self.assertEqual(self.geometry.get_coordinates(loc1), (1.0, 2.0, 3.0))
+
+        loc2 = self._make_relative_location(4.0, 5.0, 6.0)
+        self.assertEqual(self.geometry.get_coordinates(loc2), (4.0, 5.0, 6.0))
+
+        loc3 = self._make_global_location(7.0, 8.0, 9.0)
+        self.assertEqual(self.geometry.get_coordinates(loc3), (7.0, 8.0, 9.0))
+
+        # A `Location` object must be provided.
+        with self.assertRaises(TypeError):
+            self.geometry.get_coordinates(None)
+
     def test_bearing_to_angle(self):
         bearing = -45.0 * math.pi/180
-        self.assertEqual(self.geometry.bearing_to_angle(bearing), 135.0 * math.pi/180)
+        self.assertEqual(self.geometry.bearing_to_angle(bearing),
+                         135.0 * math.pi/180)
 
     def test_angle_to_bearing(self):
         angle = 180.0 * math.pi/180
-        self.assertEqual(self.geometry.angle_to_bearing(angle), 270.0 * math.pi/180)
+        self.assertEqual(self.geometry.angle_to_bearing(angle),
+                         270.0 * math.pi/180)
 
     def test_get_location_local(self):
-        loc = LocationLocal(7.6, 5.4, -3.2)
-        self.assertEqual(self.geometry.get_location_local(loc), loc)
+        local_location = LocationLocal(7.6, 5.4, -3.2)
+        self.assertEqual(self.geometry.get_location_local(local_location),
+                         local_location)
 
-        locations_mock = Mock(spec_set=Locations)
-        local_mock = PropertyMock(return_value=loc)
-        type(locations_mock).local_frame = local_mock
-        self.assertEqual(self.geometry.get_location_local(locations_mock), loc)
-        local_mock.assert_called_once_with()
+        self.local_mock.configure_mock(return_value=local_location)
+        self.assertEqual(self.geometry.get_location_local(self.locations_mock),
+                         local_location)
+        self.local_mock.assert_called_once_with()
 
     def test_get_location_local_other(self):
+        # Base geometry does not support relative or global locations.
         with self.assertRaises(TypeError):
-            self.geometry.get_location_local(LocationGlobal(1.0, 2.0, 3.0))
+            self.geometry.get_location_local(self.global_location)
         with self.assertRaises(TypeError):
-            self.geometry.get_location_local(LocationGlobalRelative(1.0, 2.0, 3.0))
+            self.geometry.get_location_local(self.relative_location)
 
     def test_get_location_frame(self):
-        loc = LocationLocal(7.6, 5.4, -3.2)
-        locations_mock = Mock(spec_set=Locations)
-        local_mock = PropertyMock(return_value=loc)
-        type(locations_mock).local_frame = local_mock
-        self.assertEqual(self.geometry.get_location_frame(locations_mock), loc)
-        local_mock.assert_called_once_with()
+        local_location = LocationLocal(7.6, 5.4, -3.2)
+        self.local_mock.configure_mock(return_value=local_location)
+        self.assertEqual(self.geometry.get_location_frame(self.locations_mock),
+                         local_location)
+        self.local_mock.assert_called_once_with()
 
     def test_get_location_frame_other(self):
+        # A `Locations` object must be given.
         with self.assertRaises(TypeError):
-            self.geometry.get_location_frame(LocationLocal(1.0, 2.0, 3.0))
+            self.geometry.get_location_frame(self.local_location)
         with self.assertRaises(TypeError):
-            self.geometry.get_location_frame(LocationGlobal(4.0, 5.0, 6.0))
+            self.geometry.get_location_frame(self.global_location)
         with self.assertRaises(TypeError):
-            self.geometry.get_location_frame(LocationGlobalRelative(7.0, 8.0, 9.0))
+            self.geometry.get_location_frame(self.relative_location)
 
-    def test_location_meters(self):
+    def test_get_location_meters(self):
         loc = LocationLocal(5.4, 3.2, -1.0)
         loc2 = LocationLocal(5.4, 3.2, -11.0)
         self.assertEqual(self.geometry.get_location_meters(loc, 0, 0, 0), loc)
         self.assertEqual(self.geometry.get_location_meters(loc, 0, 0, 10), loc2)
 
-    def test_distance_meters(self):
+    def test_get_distance_meters(self):
         loc = LocationLocal(5.4, 3.2, -1.0)
         # 3 * 3 + 4 * 4 = 9 + 16 = 25 which is 5 squared.
         loc2 = self.geometry.get_location_meters(loc, 3.0, 4.0)
-        self.assertAlmostEqual(self.geometry.get_distance_meters(loc, loc2), 5.0, delta=self.dist_delta)
+        self.assertAlmostEqual(self.geometry.get_distance_meters(loc, loc2),
+                               5.0, delta=self.dist_delta)
 
     def test_diff_location(self):
         loc = LocationLocal(5.4, 3.2, -1.0)
@@ -178,30 +257,38 @@ class TestGeometry(LocationTestCase):
                                              -p[2] if len(p) > 2 else 0.0)
                 self.assertEqual(actual_loc, expected_loc)
 
-    def test_location_angle(self):
+    def test_get_location_angle(self):
         loc = LocationLocal(5.0, 3.0, -1.0)
-        loc2 = self.geometry.get_location_meters(loc, 10, math.sqrt(200), math.sqrt(200))
-        cl = self.geometry.get_location_angle(loc, 20, 45.0 * math.pi/180, 45.0 * math.pi/180)
+        loc2 = self.geometry.get_location_meters(loc, 10, math.sqrt(200),
+                                                 math.sqrt(200))
+        cl = self.geometry.get_location_angle(loc, 20, 45.0 * math.pi/180,
+                                              45.0 * math.pi/180)
         self.assertAlmostEqual(cl.north, loc2.north, delta=self.coord_delta)
         self.assertAlmostEqual(cl.east, loc2.east, delta=self.coord_delta)
         self.assertAlmostEqual(cl.down, loc2.down, delta=self.coord_delta)
 
-        angle = self.geometry.get_angle(loc, self.geometry.get_location_angle(loc, 10.0, math.pi/4))
+        other_loc = self.geometry.get_location_angle(loc, 10.0, math.pi/4)
+        angle = self.geometry.get_angle(loc, other_loc)
         self.assertAlmostEqual(angle, math.pi/4, delta=self.angle_delta)
 
     def test_get_angle(self):
         loc = LocationLocal(5.4, 3.2, -1.0)
         loc2 = self.geometry.get_location_meters(loc, 10.0, 10.0, 0.0)
-        self.assertAlmostEqual(self.geometry.get_angle(loc, loc2), 45.0 * math.pi/180, delta=self.angle_delta)
+        self.assertAlmostEqual(self.geometry.get_angle(loc, loc2),
+                               45.0 * math.pi/180, delta=self.angle_delta)
 
     def test_diff_angle(self):
         self.assertEqual(self.geometry.diff_angle(math.pi, 3*math.pi), 0.0)
-        self.assertEqual(abs(self.geometry.diff_angle(-math.pi/2, math.pi/2)), math.pi)
+        self.assertEqual(abs(self.geometry.diff_angle(-math.pi/2, math.pi/2)),
+                         math.pi)
 
     def test_check_angle(self):
-        self.assertEqual(self.geometry.check_angle(math.pi, 3*math.pi, 0.0), True)
-        self.assertEqual(self.geometry.check_angle(-math.pi/2, math.pi/2, math.pi/4), False)
-        self.assertEqual(self.geometry.check_angle(2.0 * math.pi/180, -2.0 * math.pi/180, 5.0 *math.pi/180), True)
+        right = math.pi/2
+        self.assertTrue(self.geometry.check_angle(math.pi, 3*math.pi, 0.0))
+        self.assertFalse(self.geometry.check_angle(-right, right, math.pi/4))
+        self.assertTrue(self.geometry.check_angle(2.0 * math.pi/180,
+                                                  -2.0 * math.pi/180,
+                                                  5.0 * math.pi/180))
 
     def test_get_direction(self):
         self.assertEqual(self.geometry.get_direction(0.0, math.pi/2), -1)
@@ -234,8 +321,8 @@ class TestGeometry(LocationTestCase):
             with patch('sys.stdout'):
                 actual = self.geometry.ray_intersects_segment(P, start, end,
                                                               verbose=True)
-                msg = "Ray from {0} must{expect} intersect start={1}, end={2}"
-                msg = msg.format(*case, expect="" if expected else " not")
+                msg = "Ray from {0} must{neg} intersect start={1}, end={2}"
+                msg = msg.format(*case, neg="" if expected else " not")
                 self.assertEqual(actual, expected, msg=msg)
 
     def test_point_inside_polygon(self):
@@ -260,7 +347,8 @@ class TestGeometry(LocationTestCase):
             for loc, expected in zip(locs, results[name]):
                 location = self._make_relative_location(*loc)
                 actual = self.geometry.point_inside_polygon(location, points)
-                msg = "Point {} must{} be inside polygon {}".format(loc, "" if expected else " not", name)
+                msg = "Point {} must{} be inside polygon {}"
+                msg = msg.format(loc, "" if expected else " not", name)
                 self.assertEqual(actual, expected, msg=msg)
 
         poly = polys["square"]
@@ -308,7 +396,7 @@ class TestGeometry(LocationTestCase):
         self.assertEqual(edges[2], (locations[2], locations[0]))
 
     def test_get_plane_distance(self):
-        start_location = self._make_relative_location(0.0, 0.0, 0.0)
+        home = self._make_relative_location(0.0, 0.0, 0.0)
         cases = [
             # Upward polygon
             {
@@ -352,34 +440,48 @@ class TestGeometry(LocationTestCase):
             }
         ]
         for case in cases:
-            face = [self.geometry.get_location_meters(start_location, *p) for p in case["points"]]
-            loc1 = self.geometry.get_location_meters(start_location, *case["location1"])
-            loc2 = self.geometry.get_location_meters(start_location, *case["location2"])
+            points = case["points"]
+            face = [self.geometry.get_location_meters(home, *p) for p in points]
+            loc1 = self.geometry.get_location_meters(home, *case["location1"])
+            loc2 = self.geometry.get_location_meters(home, *case["location2"])
             with patch('sys.stdout'):
                 dist, point = self.geometry.get_plane_distance(face,
                                                                loc1, loc2,
                                                                verbose=True)
 
-            self.assertAlmostEqual(dist, case["distance"], delta=self.dist_delta)
+            self.assertAlmostEqual(dist, case["distance"],
+                                   delta=self.dist_delta)
             if case["loc_point"] is None:
                 self.assertIsNone(point)
             else:
                 actual = self.geometry.get_location_local(point)
-                loc_point = self.geometry.get_location_meters(start_location, *case["loc_point"])
-                expected = self.geometry.get_location_local(loc_point)
-                self.assertAlmostEqual(actual.north, expected.north, delta=self.coord_delta)
-                self.assertAlmostEqual(actual.east, expected.east, delta=self.coord_delta)
-                self.assertAlmostEqual(actual.down, expected.down, delta=self.coord_delta)
+                location = self.geometry.get_location_meters(home,
+                                                             *case["loc_point"])
+                expected = self.geometry.get_location_local(location)
+                self.assertAlmostEqual(actual.north, expected.north,
+                                       delta=self.coord_delta)
+                self.assertAlmostEqual(actual.east, expected.east,
+                                       delta=self.coord_delta)
+                self.assertAlmostEqual(actual.down, expected.down,
+                                       delta=self.coord_delta)
 
-class TestGeometry_Grid(TestGeometry):
+class TestGeometryGrid(TestGeometry):
+    """
+    Grid geometry test case.
+
+    This tests the `Geometry_Grid` class. All test methods are inherited from
+    `TestGeometry`, but some are overridden here.
+    """
+
     def setUp(self):
-        super(TestGeometry_Grid, self).setUp()
+        super(TestGeometryGrid, self).setUp()
         self.geometry = Geometry_Grid()
 
-    def test_distance_meters(self):
+    def test_get_distance_meters(self):
         loc = LocationLocal(5.0, 2.0, -1.0)
         loc2 = self.geometry.get_location_meters(loc, 3.0, 4.0)
-        self.assertAlmostEqual(self.geometry.get_distance_meters(loc, loc2), 7.0, delta=self.dist_delta)
+        self.assertAlmostEqual(self.geometry.get_distance_meters(loc, loc2),
+                               7.0, delta=self.dist_delta)
 
     def test_get_neighbor_offsets(self):
         offsets = self.geometry.get_neighbor_offsets()
@@ -390,9 +492,17 @@ class TestGeometry_Grid(TestGeometry):
                                                   (0, -1),           (0, 1),
                                                             (1, 0)         ]))
 
-class TestGeometry_Spherical(TestGeometry):
+class TestGeometrySpherical(TestGeometry):
+    """
+    Grid geometry test case.
+
+    This tests the `Geometry_Grid` class. All test methods are inherited from
+    `TestGeometry`, but some are overridden here and new test methods are added
+    to cover the additional interface.
+    """
+
     def setUp(self):
-        super(TestGeometry_Spherical, self).setUp()
+        super(TestGeometrySpherical, self).setUp()
         self.geometry = Geometry_Spherical()
         # Up to 2 cm accuracy. Geometry is precise, but Geometry_Spherical has 
         # some rounding due to coordinate precision.
@@ -409,87 +519,116 @@ class TestGeometry_Spherical(TestGeometry):
     def _make_relative_location(self, x, y, z=0.0):
         return LocationGlobalRelative(x, y, z)
 
-    def test_home_location_type(self):
+    def test_set_home_location_type(self):
+        # Spherical geometry requires a global location as home location.
         with self.assertRaises(TypeError):
-            self.geometry.set_home_location(LocationGlobalRelative(3.0, 2.0, 1.0))
+            self.geometry.set_home_location(self.relative_location)
 
         with self.assertRaises(TypeError):
-            self.geometry.set_home_location(LocationLocal(3.0, 2.0, 1.0))
+            self.geometry.set_home_location(self.local_location)
 
-        locations_mock = Mock(spec_set=Locations)
-        global_mock = PropertyMock(return_value=LocationGlobal(3.0, 2.0, 1.0))
-        type(locations_mock).global_frame = global_mock
-        self.geometry.set_home_location(locations_mock)
-        global_mock.assert_called_once_with()
+        global_location = LocationGlobal(3.0, 2.0, 1.0)
+        self.global_mock.configure_mock(return_value=global_location)
+        self.geometry.set_home_location(self.locations_mock)
+        self.global_mock.assert_called_once_with()
+        self.assertEqual(self.geometry.home_location, global_location)
+
+    def test_get_coordinates_other(self):
+        relative_location = LocationGlobalRelative(3.0, 2.0, 1.0)
+        self.relative_mock.configure_mock(return_value=relative_location)
+        self.assertEqual(self.geometry.get_coordinates(self.locations_mock),
+                         (3.0, 2.0, 1.0))
+        self.relative_mock.assert_called_once_with()
 
     def test_get_location_local_other(self):
         home_loc = self._make_global_location(5.0, 3.14, 10.0)
         self.geometry.set_home_location(home_loc)
 
-        relative_loc = self.geometry.get_location_meters(home_loc, 0.4, 0.06, 1.0)
+        rel_loc = self.geometry.get_location_meters(home_loc, 0.4, 0.06, 1.0)
         local_loc = LocationLocal(0.4, 0.06, -1.0)
-        new_loc = self.geometry.get_location_local(relative_loc)
-        self.assertAlmostEqual(new_loc.north, local_loc.north, delta=self.coord_delta)
-        self.assertAlmostEqual(new_loc.east, local_loc.east, delta=self.coord_delta)
-        self.assertAlmostEqual(new_loc.down, local_loc.down, delta=self.coord_delta)
+        new_loc = self.geometry.get_location_local(rel_loc)
+        self.assertAlmostEqual(new_loc.north, local_loc.north,
+                               delta=self.coord_delta)
+        self.assertAlmostEqual(new_loc.east, local_loc.east,
+                               delta=self.coord_delta)
+        self.assertAlmostEqual(new_loc.down, local_loc.down,
+                               delta=self.coord_delta)
 
-        global_loc = LocationGlobal(relative_loc.lat, relative_loc.lon, 11.0)
+        global_loc = LocationGlobal(rel_loc.lat, rel_loc.lon, 11.0)
         new_loc = self.geometry.get_location_local(global_loc)
-        self.assertAlmostEqual(new_loc.north, local_loc.north, delta=self.coord_delta)
-        self.assertAlmostEqual(new_loc.east, local_loc.east, delta=self.coord_delta)
-        self.assertAlmostEqual(new_loc.down, local_loc.down, delta=self.coord_delta)
+        self.assertAlmostEqual(new_loc.north, local_loc.north,
+                               delta=self.coord_delta)
+        self.assertAlmostEqual(new_loc.east, local_loc.east,
+                               delta=self.coord_delta)
+        self.assertAlmostEqual(new_loc.down, local_loc.down,
+                               delta=self.coord_delta)
 
     def test_get_location_frame(self):
-        loc = LocationGlobalRelative(7.6, 5.4, 3.2)
-        locations_mock = Mock(spec_set=Locations)
-        global_relative_mock = PropertyMock(return_value=loc)
-        type(locations_mock).global_relative_frame = global_relative_mock
-        self.assertEqual(self.geometry.get_location_frame(locations_mock), loc)
-        global_relative_mock.assert_called_once_with()
+        with self.assertRaises(TypeError):
+            self.geometry.get_location_frame(self.global_location)
+
+        relative_location = LocationGlobalRelative(7.6, 5.4, 3.2)
+        self.relative_mock.configure_mock(return_value=relative_location)
+        self.assertEqual(self.geometry.get_location_frame(self.locations_mock),
+                         relative_location)
+        self.relative_mock.assert_called_once_with()
 
     def test_get_locations_frame(self):
-        locations_mock = Mock(spec_set=Locations)
-
-        global_relative_loc = LocationGlobalRelative(6.0, 5.0, 4.0)
+        relative_loc = LocationGlobalRelative(6.0, 5.0, 4.0)
         global_loc = LocationGlobal(3.0, 2.0, 1.0)
         local_loc = LocationLocal(0.0, -1.0, -2.0)
 
-        global_relative_mock = PropertyMock(return_value=global_relative_loc)
-        global_mock = PropertyMock(return_value=global_loc)
-        local_mock = PropertyMock(return_value=local_loc)
-
-        type(locations_mock).global_relative_frame = global_relative_mock
-        type(locations_mock).global_frame = global_mock
-        type(locations_mock).local_frame = local_mock
+        self.relative_mock.configure_mock(return_value=relative_loc)
+        self.global_mock.configure_mock(return_value=global_loc)
+        self.local_mock.configure_mock(return_value=local_loc)
 
         loc1 = LocationGlobalRelative(5.4, 3.2, 1.0)
-        self.assertEqual(self.geometry.get_locations_frame(locations_mock, loc1), global_relative_loc)
-        global_relative_mock.assert_called_once_with()
+        frame_loc = self.geometry.get_locations_frame(self.locations_mock, loc1)
+        self.assertEqual(frame_loc, relative_loc)
+        self.relative_mock.assert_called_once_with()
 
         loc2 = LocationGlobal(8.6, 4.2, 0.8)
-        self.assertEqual(self.geometry.get_locations_frame(locations_mock, loc2), global_loc)
-        global_mock.assert_called_once_with()
+        frame_loc = self.geometry.get_locations_frame(self.locations_mock, loc2)
+        self.assertEqual(frame_loc, global_loc)
+        self.global_mock.assert_called_once_with()
 
         loc3 = LocationLocal(-2.0, 4.5, -2.5)
-        self.assertEqual(self.geometry.get_locations_frame(locations_mock, loc3), local_loc)
-        local_mock.assert_called_once_with()
+        frame_loc = self.geometry.get_locations_frame(self.locations_mock, loc3)
+        self.assertEqual(frame_loc, local_loc)
+        self.local_mock.assert_called_once_with()
+
+        # Correct location types must be provided.
+        with self.assertRaisesRegexp(TypeError, "`Locations`"):
+            self.geometry.get_locations_frame(None, loc3)
+        with self.assertRaisesRegexp(TypeError, "`Location`"):
+            self.geometry.get_locations_frame(self.locations_mock, None)
 
     def test_equalize(self):
         home_loc = self._make_global_location(5.0, 3.14, 10.0)
         self.geometry.set_home_location(home_loc)
         loc1 = self.geometry.get_location_meters(home_loc, 0.4, 0.06, 1.0)
         loc2 = LocationLocal(0.4, 0.06, -1.0)
+        loc3 = LocationGlobalRelative(5.0, 3.14, 0.0)
         self.assertEqual(*self.geometry.equalize(loc1, loc2))
+        self.assertEqual(*self.geometry.equalize(home_loc, loc3))
 
-        locations_mock = Mock(spec_set=Locations)
-        local_mock = PropertyMock(return_value=loc2)
-        type(locations_mock).local_frame = local_mock
-        self.assertEqual(*self.geometry.equalize(locations_mock, loc2))
-        local_mock.assert_called_once_with()
+        self.local_mock.configure_mock(return_value=loc2)
+        self.relative_mock.configure_mock(return_value=loc3)
+        self.assertEqual(*self.geometry.equalize(self.locations_mock, loc2))
+        self.local_mock.assert_called_once_with()
 
-        local_mock.reset_mock()
-        self.assertEqual(*self.geometry.equalize(loc2, locations_mock))
-        local_mock.assert_called_once_with()
+        self.local_mock.reset_mock()
+        self.assertEqual(*self.geometry.equalize(loc2, self.locations_mock))
+        self.local_mock.assert_called_once_with()
+
+        self.assertEqual(*self.geometry.equalize(self.locations_mock,
+                                                 self.locations_mock))
+        self.assertEqual(self.relative_mock.call_count, 2)
+
+        with self.assertRaisesRegexp(TypeError, "`location1`"):
+            self.geometry.equalize(None, loc2)
+        with self.assertRaisesRegexp(TypeError, "`location2`"):
+            self.geometry.equalize(loc1, None)
 
     def test_make_location(self):
         loc = LocationGlobalRelative(1.0, 2.0, 3.0)

--- a/tests/geometry.py
+++ b/tests/geometry.py
@@ -12,8 +12,6 @@ from dronekit import LocationGlobal, LocationGlobalRelative, LocationLocal, Loca
 
 # Package imports
 from ..geometry.Geometry import Geometry
-from ..geometry.Geometry_Grid import Geometry_Grid
-from ..geometry.Geometry_Spherical import Geometry_Spherical
 
 class LocationTestCase(unittest.TestCase):
     """
@@ -49,7 +47,7 @@ class LocationTestCase(unittest.TestCase):
 
 class TestGeometry(LocationTestCase):
     """
-    Geometry test class.
+    Test case class for base Geometry tests.
 
     This class tests the `Geometry` interface. It can be subclassed in order
     to test the subclasses of `Geometry`. The test methods are then inherited,
@@ -58,8 +56,13 @@ class TestGeometry(LocationTestCase):
 
     def setUp(self):
         super(TestGeometry, self).setUp()
+
+        # Geometry object to use in the tests.
         self.geometry = Geometry()
-        # Handle float inaccuracies
+
+        # Delta values for approximate equality checks.
+        # The default values handle float inaccuracies that may be caused by 
+        # conversions in the geometry class.
         self.dist_delta = sys.float_info.epsilon * 10
         self.coord_delta = self.dist_delta
         self.angle_delta = sys.float_info.epsilon * 10
@@ -464,172 +467,3 @@ class TestGeometry(LocationTestCase):
                                        delta=self.coord_delta)
                 self.assertAlmostEqual(actual.down, expected.down,
                                        delta=self.coord_delta)
-
-class TestGeometryGrid(TestGeometry):
-    """
-    Grid geometry test case.
-
-    This tests the `Geometry_Grid` class. All test methods are inherited from
-    `TestGeometry`, but some are overridden here.
-    """
-
-    def setUp(self):
-        super(TestGeometryGrid, self).setUp()
-        self.geometry = Geometry_Grid()
-
-    def test_get_distance_meters(self):
-        loc = LocationLocal(5.0, 2.0, -1.0)
-        loc2 = self.geometry.get_location_meters(loc, 3.0, 4.0)
-        self.assertAlmostEqual(self.geometry.get_distance_meters(loc, loc2),
-                               7.0, delta=self.dist_delta)
-
-    def test_get_neighbor_offsets(self):
-        offsets = self.geometry.get_neighbor_offsets()
-        self.assertEqual(offsets.shape, (4, 2))
-
-        # pylint: disable=bad-continuation,bad-whitespace
-        self.assertTrue(np.array_equal(offsets, [          (-1, 0),
-                                                  (0, -1),           (0, 1),
-                                                            (1, 0)         ]))
-
-class TestGeometrySpherical(TestGeometry):
-    """
-    Grid geometry test case.
-
-    This tests the `Geometry_Grid` class. All test methods are inherited from
-    `TestGeometry`, but some are overridden here and new test methods are added
-    to cover the additional interface.
-    """
-
-    def setUp(self):
-        super(TestGeometrySpherical, self).setUp()
-        self.geometry = Geometry_Spherical()
-        # Up to 2 cm accuracy. Geometry is precise, but Geometry_Spherical has 
-        # some rounding due to coordinate precision.
-        self.dist_delta = 0.02
-        self.coord_delta = self.dist_delta / self.geometry.EARTH_RADIUS
-        # Up to 0.15 degrees accuracy. Geometry is precise, but 
-        # Geometry_Spherical has some rounding due to get_angle not taking 
-        # curvature into account.
-        self.angle_delta = 0.15 * math.pi/180
-
-    def _make_global_location(self, x, y, z=0.0):
-        return LocationGlobal(x, y, z)
-
-    def _make_relative_location(self, x, y, z=0.0):
-        return LocationGlobalRelative(x, y, z)
-
-    def test_set_home_location_type(self):
-        # Spherical geometry requires a global location as home location.
-        with self.assertRaises(TypeError):
-            self.geometry.set_home_location(self.relative_location)
-
-        with self.assertRaises(TypeError):
-            self.geometry.set_home_location(self.local_location)
-
-        global_location = LocationGlobal(3.0, 2.0, 1.0)
-        self.global_mock.configure_mock(return_value=global_location)
-        self.geometry.set_home_location(self.locations_mock)
-        self.global_mock.assert_called_once_with()
-        self.assertEqual(self.geometry.home_location, global_location)
-
-    def test_get_coordinates_other(self):
-        relative_location = LocationGlobalRelative(3.0, 2.0, 1.0)
-        self.relative_mock.configure_mock(return_value=relative_location)
-        self.assertEqual(self.geometry.get_coordinates(self.locations_mock),
-                         (3.0, 2.0, 1.0))
-        self.relative_mock.assert_called_once_with()
-
-    def test_get_location_local_other(self):
-        home_loc = self._make_global_location(5.0, 3.14, 10.0)
-        self.geometry.set_home_location(home_loc)
-
-        rel_loc = self.geometry.get_location_meters(home_loc, 0.4, 0.06, 1.0)
-        local_loc = LocationLocal(0.4, 0.06, -1.0)
-        new_loc = self.geometry.get_location_local(rel_loc)
-        self.assertAlmostEqual(new_loc.north, local_loc.north,
-                               delta=self.coord_delta)
-        self.assertAlmostEqual(new_loc.east, local_loc.east,
-                               delta=self.coord_delta)
-        self.assertAlmostEqual(new_loc.down, local_loc.down,
-                               delta=self.coord_delta)
-
-        global_loc = LocationGlobal(rel_loc.lat, rel_loc.lon, 11.0)
-        new_loc = self.geometry.get_location_local(global_loc)
-        self.assertAlmostEqual(new_loc.north, local_loc.north,
-                               delta=self.coord_delta)
-        self.assertAlmostEqual(new_loc.east, local_loc.east,
-                               delta=self.coord_delta)
-        self.assertAlmostEqual(new_loc.down, local_loc.down,
-                               delta=self.coord_delta)
-
-    def test_get_location_frame(self):
-        with self.assertRaises(TypeError):
-            self.geometry.get_location_frame(self.global_location)
-
-        relative_location = LocationGlobalRelative(7.6, 5.4, 3.2)
-        self.relative_mock.configure_mock(return_value=relative_location)
-        self.assertEqual(self.geometry.get_location_frame(self.locations_mock),
-                         relative_location)
-        self.relative_mock.assert_called_once_with()
-
-    def test_get_locations_frame(self):
-        relative_loc = LocationGlobalRelative(6.0, 5.0, 4.0)
-        global_loc = LocationGlobal(3.0, 2.0, 1.0)
-        local_loc = LocationLocal(0.0, -1.0, -2.0)
-
-        self.relative_mock.configure_mock(return_value=relative_loc)
-        self.global_mock.configure_mock(return_value=global_loc)
-        self.local_mock.configure_mock(return_value=local_loc)
-
-        loc1 = LocationGlobalRelative(5.4, 3.2, 1.0)
-        frame_loc = self.geometry.get_locations_frame(self.locations_mock, loc1)
-        self.assertEqual(frame_loc, relative_loc)
-        self.relative_mock.assert_called_once_with()
-
-        loc2 = LocationGlobal(8.6, 4.2, 0.8)
-        frame_loc = self.geometry.get_locations_frame(self.locations_mock, loc2)
-        self.assertEqual(frame_loc, global_loc)
-        self.global_mock.assert_called_once_with()
-
-        loc3 = LocationLocal(-2.0, 4.5, -2.5)
-        frame_loc = self.geometry.get_locations_frame(self.locations_mock, loc3)
-        self.assertEqual(frame_loc, local_loc)
-        self.local_mock.assert_called_once_with()
-
-        # Correct location types must be provided.
-        with self.assertRaisesRegexp(TypeError, "`Locations`"):
-            self.geometry.get_locations_frame(None, loc3)
-        with self.assertRaisesRegexp(TypeError, "`Location`"):
-            self.geometry.get_locations_frame(self.locations_mock, None)
-
-    def test_equalize(self):
-        home_loc = self._make_global_location(5.0, 3.14, 10.0)
-        self.geometry.set_home_location(home_loc)
-        loc1 = self.geometry.get_location_meters(home_loc, 0.4, 0.06, 1.0)
-        loc2 = LocationLocal(0.4, 0.06, -1.0)
-        loc3 = LocationGlobalRelative(5.0, 3.14, 0.0)
-        self.assertEqual(*self.geometry.equalize(loc1, loc2))
-        self.assertEqual(*self.geometry.equalize(home_loc, loc3))
-
-        self.local_mock.configure_mock(return_value=loc2)
-        self.relative_mock.configure_mock(return_value=loc3)
-        self.assertEqual(*self.geometry.equalize(self.locations_mock, loc2))
-        self.local_mock.assert_called_once_with()
-
-        self.local_mock.reset_mock()
-        self.assertEqual(*self.geometry.equalize(loc2, self.locations_mock))
-        self.local_mock.assert_called_once_with()
-
-        self.assertEqual(*self.geometry.equalize(self.locations_mock,
-                                                 self.locations_mock))
-        self.assertEqual(self.relative_mock.call_count, 2)
-
-        with self.assertRaisesRegexp(TypeError, "`location1`"):
-            self.geometry.equalize(None, loc2)
-        with self.assertRaisesRegexp(TypeError, "`location2`"):
-            self.geometry.equalize(loc1, None)
-
-    def test_make_location(self):
-        loc = LocationGlobalRelative(1.0, 2.0, 3.0)
-        self.assertEqual(self.geometry.make_location(1.0, 2.0, 3.0), loc)

--- a/tests/geometry_grid.py
+++ b/tests/geometry_grid.py
@@ -1,0 +1,31 @@
+import numpy as np
+from dronekit import LocationLocal
+from ..geometry.Geometry_Grid import Geometry_Grid
+import geometry
+
+class TestGeometryGrid(geometry.TestGeometry):
+    """
+    Grid geometry test case.
+
+    This tests the `Geometry_Grid` class. All test methods are inherited from
+    `GeometryTestCase`, but some are overridden here.
+    """
+
+    def setUp(self):
+        super(TestGeometryGrid, self).setUp()
+        self.geometry = Geometry_Grid()
+
+    def test_get_distance_meters(self):
+        loc = LocationLocal(5.0, 2.0, -1.0)
+        loc2 = self.geometry.get_location_meters(loc, 3.0, 4.0)
+        self.assertAlmostEqual(self.geometry.get_distance_meters(loc, loc2),
+                               7.0, delta=self.dist_delta)
+
+    def test_get_neighbor_offsets(self):
+        offsets = self.geometry.get_neighbor_offsets()
+        self.assertEqual(offsets.shape, (4, 2))
+
+        # pylint: disable=bad-continuation,bad-whitespace
+        self.assertTrue(np.array_equal(offsets, [          (-1, 0),
+                                                  (0, -1),           (0, 1),
+                                                            (1, 0)         ]))

--- a/tests/geometry_spherical.py
+++ b/tests/geometry_spherical.py
@@ -1,0 +1,146 @@
+import math
+from dronekit import LocationGlobal, LocationGlobalRelative, LocationLocal
+from ..geometry.Geometry_Spherical import Geometry_Spherical
+import geometry
+
+class TestGeometrySpherical(geometry.TestGeometry):
+    """
+    Grid geometry test case.
+
+    This tests the `Geometry_Spherical` class. All test methods are inherited
+    from `TestGeometry`, but some are overridden here and new test methods
+    are added to cover the additional interface.
+    """
+
+    def setUp(self):
+        super(TestGeometrySpherical, self).setUp()
+        self.geometry = Geometry_Spherical()
+        # Up to 2 cm accuracy. Geometry is precise, but Geometry_Spherical has 
+        # some rounding due to coordinate precision.
+        self.dist_delta = 0.02
+        self.coord_delta = self.dist_delta / self.geometry.EARTH_RADIUS
+        # Up to 0.15 degrees accuracy. Geometry is precise, but 
+        # Geometry_Spherical has some rounding due to get_angle not taking 
+        # curvature into account.
+        self.angle_delta = 0.15 * math.pi/180
+
+    def _make_global_location(self, x, y, z=0.0):
+        return LocationGlobal(x, y, z)
+
+    def _make_relative_location(self, x, y, z=0.0):
+        return LocationGlobalRelative(x, y, z)
+
+    def test_set_home_location_type(self):
+        # Spherical geometry requires a global location as home location.
+        with self.assertRaises(TypeError):
+            self.geometry.set_home_location(self.relative_location)
+
+        with self.assertRaises(TypeError):
+            self.geometry.set_home_location(self.local_location)
+
+        global_location = LocationGlobal(3.0, 2.0, 1.0)
+        self.global_mock.configure_mock(return_value=global_location)
+        self.geometry.set_home_location(self.locations_mock)
+        self.global_mock.assert_called_once_with()
+        self.assertEqual(self.geometry.home_location, global_location)
+
+    def test_get_coordinates_other(self):
+        relative_location = LocationGlobalRelative(3.0, 2.0, 1.0)
+        self.relative_mock.configure_mock(return_value=relative_location)
+        self.assertEqual(self.geometry.get_coordinates(self.locations_mock),
+                         (3.0, 2.0, 1.0))
+        self.relative_mock.assert_called_once_with()
+
+    def test_get_location_local_other(self):
+        home_loc = self._make_global_location(5.0, 3.14, 10.0)
+        self.geometry.set_home_location(home_loc)
+
+        rel_loc = self.geometry.get_location_meters(home_loc, 0.4, 0.06, 1.0)
+        local_loc = LocationLocal(0.4, 0.06, -1.0)
+        new_loc = self.geometry.get_location_local(rel_loc)
+        self.assertAlmostEqual(new_loc.north, local_loc.north,
+                               delta=self.coord_delta)
+        self.assertAlmostEqual(new_loc.east, local_loc.east,
+                               delta=self.coord_delta)
+        self.assertAlmostEqual(new_loc.down, local_loc.down,
+                               delta=self.coord_delta)
+
+        global_loc = LocationGlobal(rel_loc.lat, rel_loc.lon, 11.0)
+        new_loc = self.geometry.get_location_local(global_loc)
+        self.assertAlmostEqual(new_loc.north, local_loc.north,
+                               delta=self.coord_delta)
+        self.assertAlmostEqual(new_loc.east, local_loc.east,
+                               delta=self.coord_delta)
+        self.assertAlmostEqual(new_loc.down, local_loc.down,
+                               delta=self.coord_delta)
+
+    def test_get_location_frame(self):
+        with self.assertRaises(TypeError):
+            self.geometry.get_location_frame(self.global_location)
+
+        relative_location = LocationGlobalRelative(7.6, 5.4, 3.2)
+        self.relative_mock.configure_mock(return_value=relative_location)
+        self.assertEqual(self.geometry.get_location_frame(self.locations_mock),
+                         relative_location)
+        self.relative_mock.assert_called_once_with()
+
+    def test_get_locations_frame(self):
+        relative_loc = LocationGlobalRelative(6.0, 5.0, 4.0)
+        global_loc = LocationGlobal(3.0, 2.0, 1.0)
+        local_loc = LocationLocal(0.0, -1.0, -2.0)
+
+        self.relative_mock.configure_mock(return_value=relative_loc)
+        self.global_mock.configure_mock(return_value=global_loc)
+        self.local_mock.configure_mock(return_value=local_loc)
+
+        loc1 = LocationGlobalRelative(5.4, 3.2, 1.0)
+        frame_loc = self.geometry.get_locations_frame(self.locations_mock, loc1)
+        self.assertEqual(frame_loc, relative_loc)
+        self.relative_mock.assert_called_once_with()
+
+        loc2 = LocationGlobal(8.6, 4.2, 0.8)
+        frame_loc = self.geometry.get_locations_frame(self.locations_mock, loc2)
+        self.assertEqual(frame_loc, global_loc)
+        self.global_mock.assert_called_once_with()
+
+        loc3 = LocationLocal(-2.0, 4.5, -2.5)
+        frame_loc = self.geometry.get_locations_frame(self.locations_mock, loc3)
+        self.assertEqual(frame_loc, local_loc)
+        self.local_mock.assert_called_once_with()
+
+        # Correct location types must be provided.
+        with self.assertRaisesRegexp(TypeError, "`Locations`"):
+            self.geometry.get_locations_frame(None, loc3)
+        with self.assertRaisesRegexp(TypeError, "`Location`"):
+            self.geometry.get_locations_frame(self.locations_mock, None)
+
+    def test_equalize(self):
+        home_loc = self._make_global_location(5.0, 3.14, 10.0)
+        self.geometry.set_home_location(home_loc)
+        loc1 = self.geometry.get_location_meters(home_loc, 0.4, 0.06, 1.0)
+        loc2 = LocationLocal(0.4, 0.06, -1.0)
+        loc3 = LocationGlobalRelative(5.0, 3.14, 0.0)
+        self.assertEqual(*self.geometry.equalize(loc1, loc2))
+        self.assertEqual(*self.geometry.equalize(home_loc, loc3))
+
+        self.local_mock.configure_mock(return_value=loc2)
+        self.relative_mock.configure_mock(return_value=loc3)
+        self.assertEqual(*self.geometry.equalize(self.locations_mock, loc2))
+        self.local_mock.assert_called_once_with()
+
+        self.local_mock.reset_mock()
+        self.assertEqual(*self.geometry.equalize(loc2, self.locations_mock))
+        self.local_mock.assert_called_once_with()
+
+        self.assertEqual(*self.geometry.equalize(self.locations_mock,
+                                                 self.locations_mock))
+        self.assertEqual(self.relative_mock.call_count, 2)
+
+        with self.assertRaisesRegexp(TypeError, "`location1`"):
+            self.geometry.equalize(None, loc2)
+        with self.assertRaisesRegexp(TypeError, "`location2`"):
+            self.geometry.equalize(loc1, None)
+
+    def test_make_location(self):
+        loc = LocationGlobalRelative(1.0, 2.0, 3.0)
+        self.assertEqual(self.geometry.make_location(1.0, 2.0, 3.0), loc)

--- a/tests/mission.py
+++ b/tests/mission.py
@@ -47,7 +47,11 @@ class TestMission(EnvironmentTestCase):
             self.mission.display()
 
     def test_check_mission(self):
-        with patch.object(self.mission, "geometry", spec=Geometry_Spherical) as geometry_mock:
+        config = {
+            "spec": Geometry_Spherical,
+            "set_home_location.side_effect": TypeError
+        }
+        with patch.object(self.mission, "geometry", **config) as geometry_mock:
             with patch("sys.stdout"):
                 loc = LocationGlobal(0.1, 2.3, 4.5)
                 self.vehicle.home_location = loc

--- a/tests/mission_auto.py
+++ b/tests/mission_auto.py
@@ -42,7 +42,7 @@ class TestMissionAuto(EnvironmentTestCase):
 
         loc = LocationGlobalRelative(4.3, 2.1, 0.0)
         new_loc = LocationGlobalRelative(4.3, 2.1, self.settings.get("altitude"))
-        with patch.object(self.mission, "geometry", spec=Geometry_Spherical):
+        with patch.object(self.mission, "geometry", new=Geometry_Spherical()):
             self.assertEqual(self.mission._convert_waypoint(loc), new_loc)
 
     def test_display(self):

--- a/tests/mission_rf_sensor.py
+++ b/tests/mission_rf_sensor.py
@@ -43,8 +43,17 @@ class TestMissionRFSensor(EnvironmentTestCase):
         self.assertFalse(self.mission.waypoints_complete)
         self.assertEqual(self.mission.next_index, 0)
 
+    def test_get_points(self):
         # An RF sensor mission has no predetermined AUTO points.
         self.assertEqual(self.mission.get_points(), [])
+
+    def test_add_commands(self):
+        with self.assertRaises(RuntimeError):
+            self.mission.add_commands()
+
+    def test_arm_and_takeoff(self):
+        with patch('sys.stdout'):
+            self.mission.setup()
 
         # Starting arming checks will wait until waypoints are complete.
         with patch('time.sleep', side_effect=RuntimeError('sleep')):
@@ -74,7 +83,7 @@ class TestMissionRFSensor(EnvironmentTestCase):
         with patch('sys.stdout'):
             self.environment.receive_packet(packet)
 
-    def test_clear(self):
+    def test_clear_waypoints(self):
         with patch('sys.stdout'):
             self.mission.setup()
 
@@ -103,7 +112,7 @@ class TestMissionRFSensor(EnvironmentTestCase):
         self.assertEqual(self.mission.next_index, 0)
         self.assertEqual(self.vehicle._waypoints, [])
 
-    def test_add(self):
+    def test_add_waypoint(self):
         with patch('sys.stdout'):
             self.mission.setup()
 
@@ -128,7 +137,7 @@ class TestMissionRFSensor(EnvironmentTestCase):
         self.assertEqual(self.mission.next_index, 1)
         self.assertEqual(self.vehicle._waypoints, [(1, 4), None])
 
-    def test_add_wait_count(self):
+    def test_add_waypoint_wait_count(self):
         with patch('sys.stdout'):
             self.mission.setup()
 
@@ -150,7 +159,7 @@ class TestMissionRFSensor(EnvironmentTestCase):
             (0, 1), None, (0, 2), None, (0, 3), None, (0, 4), None
         ])
 
-    def test_add_wrong_index(self):
+    def test_add_waypoint_wrong_index(self):
         with patch('sys.stdout'):
             self.mission.setup()
 
@@ -170,7 +179,7 @@ class TestMissionRFSensor(EnvironmentTestCase):
         self.assertEqual(self.mission.next_index, 0)
         self.assertEqual(self.vehicle._waypoints, [])
 
-    def test_done(self):
+    def test_complete_waypoints(self):
         with patch('sys.stdout'):
             self.mission.setup()
 
@@ -196,7 +205,7 @@ class TestMissionRFSensor(EnvironmentTestCase):
             (1, 0), None, (2, 0), None, (3, 0), None, (4, 0), None
         ])
 
-    def test_move(self):
+    def test_interface_mission(self):
         with patch('sys.stdout'):
             self.mission.setup()
 

--- a/tests/mission_rf_sensor.py
+++ b/tests/mission_rf_sensor.py
@@ -59,6 +59,7 @@ class TestMissionRFSensor(EnvironmentTestCase):
         packet.set("longitude", longitude)
         packet.set("altitude", 0.0)
         packet.set("wait_id", 0)
+        packet.set("wait_count", 1)
         packet.set("to_id", self.rf_sensor.id + id_offset)
 
         with patch('sys.stdout'):

--- a/tests/vehicle_mavlink_vehicle.py
+++ b/tests/vehicle_mavlink_vehicle.py
@@ -102,7 +102,7 @@ class TestVehicleMockVehicle(VehicleTestCase):
         self.assertEqual(self.vehicle.get_waypoint(),
                          LocationLocal(3.4, 2.3, -1.2))
 
-        with patch.object(self.vehicle, "_geometry", spec=Geometry_Spherical):
+        with patch.object(self.vehicle, "_geometry", new=Geometry_Spherical()):
             self.assertEqual(self.vehicle.get_waypoint(),
                              LocationGlobalRelative(3.4, 2.3, 1.2))
 
@@ -130,7 +130,7 @@ class TestVehicleMockVehicle(VehicleTestCase):
             location_mock.return_value.configure_mock(local_frame=loc)
             self.assertFalse(self.vehicle.is_current_location_valid())
 
-            with patch.object(self.vehicle, "_geometry", spec=Geometry_Spherical):
+            with patch.object(self.vehicle, "_geometry", new=Geometry_Spherical()):
                 loc = LocationGlobalRelative(4, 5, 6)
                 location_mock.return_value.configure_mock(global_relative_frame=loc)
                 self.assertTrue(self.vehicle.is_current_location_valid())

--- a/tests/vehicle_mavlink_vehicle.py
+++ b/tests/vehicle_mavlink_vehicle.py
@@ -1,4 +1,4 @@
-from dronekit import Command, LocationLocal, LocationGlobalRelative
+from dronekit import Command, Locations, LocationLocal, LocationGlobalRelative
 from pymavlink import mavutil
 from mock import patch, Mock, PropertyMock
 from ..geometry.Geometry_Spherical import Geometry_Spherical
@@ -120,21 +120,25 @@ class TestVehicleMockVehicle(VehicleTestCase):
         commands_mock.return_value.configure_mock(count=2)
         self.assertEqual(self.vehicle.count_waypoints(), 2)
 
-    def test_is_current_location_valid(self):
-        with patch.object(MAVLink_Vehicle, "location", new_callable=PropertyMock) as location_mock:
-            loc = LocationLocal(1, 2, 3)
-            location_mock.return_value.configure_mock(local_frame=loc)
+    @patch.object(MAVLink_Vehicle, "location", new_callable=PropertyMock)
+    def test_is_current_location_valid(self, location_mock):
+        loc = LocationLocal(1, 2, 3)
+        location_mock.return_value.configure_mock(__class__=Locations,
+                                                  local_frame=loc)
+        self.assertTrue(self.vehicle.is_current_location_valid())
+
+        loc = LocationLocal(None, 2, 3)
+        location_mock.return_value.configure_mock(__class__=Locations,
+                                                  local_frame=loc)
+        self.assertFalse(self.vehicle.is_current_location_valid())
+
+        with patch.object(self.vehicle, "_geometry", new=Geometry_Spherical()):
+            loc = LocationGlobalRelative(4, 5, 6)
+            location_mock.return_value.configure_mock(__class__=Locations,
+                                                      global_relative_frame=loc)
             self.assertTrue(self.vehicle.is_current_location_valid())
 
-            loc = LocationLocal(None, 2, 3)
-            location_mock.return_value.configure_mock(local_frame=loc)
+            loc = LocationGlobalRelative(6.7, 8.9, None)
+            location_mock.return_value.configure_mock(__class__=Locations,
+                                                      global_relative_frame=loc)
             self.assertFalse(self.vehicle.is_current_location_valid())
-
-            with patch.object(self.vehicle, "_geometry", new=Geometry_Spherical()):
-                loc = LocationGlobalRelative(4, 5, 6)
-                location_mock.return_value.configure_mock(global_relative_frame=loc)
-                self.assertTrue(self.vehicle.is_current_location_valid())
-
-                loc = LocationGlobalRelative(6.7, 8.9, None)
-                location_mock.return_value.configure_mock(global_relative_frame=loc)
-                self.assertFalse(self.vehicle.is_current_location_valid())

--- a/tests/vehicle_robot_vehicle.py
+++ b/tests/vehicle_robot_vehicle.py
@@ -1,8 +1,9 @@
 import math
-from dronekit import LocationLocal, LocationGlobal, VehicleMode
+from dronekit import LocationLocal, LocationGlobal, LocationGlobalRelative, VehicleMode
 from mock import patch, MagicMock
 from ..core.Threadable import Threadable
 from ..core.WiringPi import WiringPi
+from ..geometry.Geometry_Spherical import Geometry_Spherical
 from ..location.Line_Follower import Line_Follower_Direction, Line_Follower_State
 from ..location.Line_Follower_Arduino import Line_Follower_Arduino
 from ..trajectory.Servo import Servo, Interval
@@ -49,11 +50,15 @@ class TestVehicleRobotVehicle(RobotVehicleTestCase):
     def test_home_location(self):
         self.vehicle.home_location = LocationLocal(1.0, 2.0, 4.0)
         self.assertEqual(self.vehicle._home_location, (1, 2))
+        self.assertEqual(self.vehicle.home_location,
+                         LocationLocal(1.0, 2.0, 0.0))
 
     def test_home_location_global(self):
-        with patch('sys.stdout'):
+        with patch.object(self.vehicle, "_geometry", new=Geometry_Spherical()):
             self.vehicle.home_location = LocationGlobal(3.0, 6.0, 1.2)
             self.assertEqual(self.vehicle._home_location, (3, 6))
+            self.assertEqual(self.vehicle.home_location,
+                             LocationGlobalRelative(3.0, 6.0, 0.0))
 
             self.vehicle.add_waypoint(LocationGlobal(4.0, 8.0, 6.4))
             self.assertEqual(self.vehicle._waypoints, [(4, 8)])

--- a/tests/zigbee_packet.py
+++ b/tests/zigbee_packet.py
@@ -28,8 +28,8 @@ class ZigBeePacketTestCase(unittest.TestCase):
         self.setting_add_message = "\n\x00\x00\x00\x00\x03bar\x01i" + \
                                    "*\x00\x00\x00\x01"
         self.setting_add_list_message = "\n\x01\x00\x00\x00\x05items" + \
-                                    "\x00\x11x\x9c\x8b6\xd4Q0\xd2Q0" + \
-                                    "\x8e\x05\x00\t\x85\x01\xe7\x01"
+                                        "\x00\x11x\x9c\x8b6\xd4Q0\xd2Q0" + \
+                                        "\x8e\x05\x00\t\x85\x01\xe7\x01"
 
 class TestZigBeePacket(ZigBeePacketTestCase):
     def test_initialization(self):

--- a/tests/zigbee_rf_sensor_physical.py
+++ b/tests/zigbee_rf_sensor_physical.py
@@ -5,44 +5,30 @@ import time
 from mock import patch, MagicMock, PropertyMock
 
 # Package imports
-from ..core.Thread_Manager import Thread_Manager
 from ..core.USB_Manager import USB_Manager
 from ..reconstruction.Buffer import Buffer
-from ..settings.Arguments import Arguments
 from ..zigbee.NTP import NTP
-from ..zigbee.Packet import Packet
 from ..zigbee.RF_Sensor_Physical import RF_Sensor_Physical
-from settings import SettingsTestCase
+from zigbee_rf_sensor import ZigBeeRFSensorTestCase
 
-class TestZigBeeRFSensorPhysical(SettingsTestCase):
+class TestZigBeeRFSensorPhysical(ZigBeeRFSensorTestCase):
     def setUp(self):
         super(TestZigBeeRFSensorPhysical, self).setUp()
 
-        self.arguments = Arguments("settings.json", ["--rf-sensor-id", "1"])
         self.settings = self.arguments.get_settings("rf_sensor_physical")
-
-        self.thread_manager = Thread_Manager()
         self.usb_manager = USB_Manager()
-        self.location_callback = MagicMock(return_value=((0, 0), 0))
-        self.receive_callback = MagicMock()
-        self.valid_callback = MagicMock(return_value=True)
 
         type_mock = PropertyMock(return_value="rf_sensor_physical")
         with patch.object(RF_Sensor_Physical, "type", new_callable=type_mock):
-            self.rf_sensor = RF_Sensor_Physical(self.arguments, self.thread_manager,
-                                                self.location_callback,
-                                                self.receive_callback,
-                                                self.valid_callback,
-                                                usb_manager=self.usb_manager)
+            self.rf_sensor = self._create_sensor(RF_Sensor_Physical,
+                                                 usb_manager=self.usb_manager)
 
     def test_initialization(self):
         # Providing an incorrect USB Manager raises an exception.
         type_mock = PropertyMock(return_value="rf_sensor_physical")
         with patch.object(RF_Sensor_Physical, "type", new_callable=type_mock):
             with self.assertRaises(TypeError):
-                RF_Sensor_Physical(self.arguments, self.thread_manager,
-                                   self.location_callback, self.receive_callback,
-                                   self.valid_callback, usb_manager=None)
+                self._create_sensor(RF_Sensor_Physical, usb_manager=None)
 
         self.assertEqual(self.rf_sensor._usb_manager, self.usb_manager)
 
@@ -59,10 +45,10 @@ class TestZigBeeRFSensorPhysical(SettingsTestCase):
         self.assertNotEqual(self.rf_sensor._discovery_callback, None)
         self.assertTrue(hasattr(self.rf_sensor._discovery_callback, "__call__"))
 
-    def test_synchronize(self):
+    @patch.object(NTP, "start")
+    def test_synchronize(self, ntp_start_mock):
         # Enable synchronization mode and mock the NTP component.
         self.settings.set("synchronize", True)
-        self.rf_sensor._ntp.start = MagicMock()
 
         # Let `time.sleep` raise an exception to exit the loop.
         with patch.object(time, "sleep", side_effect=RuntimeError) as sleep_mock:
@@ -70,55 +56,49 @@ class TestZigBeeRFSensorPhysical(SettingsTestCase):
                 self.rf_sensor._synchronize()
 
             # The NTP component must be called to start synchronization.
-            self.rf_sensor._ntp.start.assert_called_once_with()
+            ntp_start_mock.assert_called_once_with()
 
             # The NTP delay must be applied.
             sleep_mock.assert_any_call(self.settings.get("ntp_delay"))
 
     def test_process(self):
         # Private packets must be passed along to the receive callback.
-        self.rf_sensor._receive_callback = MagicMock()
+        with patch.object(self.rf_sensor, "_receive_callback") as receive_callback_mock:
+            self.packet.set("specification", "waypoint_clear")
 
-        packet = Packet()
-        packet.set("specification", "waypoint_clear")
+            self.rf_sensor._process(self.packet)
+            receive_callback_mock.assert_called_once_with(self.packet)
 
-        self.rf_sensor._process(packet)
-        self.rf_sensor._receive_callback.assert_called_once_with(packet)
+        with patch.object(NTP, "process") as ntp_process_mock:
+            # NTP synchronization packets must be handled.
+            self.packet.set("specification", "ntp")
 
-        # NTP synchronization packets must be handled.
-        self.rf_sensor._ntp.process = MagicMock()
-
-        packet = Packet()
-        packet.set("specification", "ntp")
-
-        self.rf_sensor._process(packet)
-        self.rf_sensor._ntp.process.assert_called_once_with(packet)
+            self.rf_sensor._process(self.packet)
+            ntp_process_mock.assert_called_once_with(self.packet)
 
         # RSSI ground station packets must be handled on the ground station.
+        buffer_mock = MagicMock(spec=Buffer)
         self.rf_sensor._id = 0
-        self.rf_sensor.buffer = MagicMock(spec=Buffer)
+        self.rf_sensor.buffer = buffer_mock
 
-        packet = Packet()
-        packet.set("specification", "rssi_ground_station")
+        self.packet.set("specification", "rssi_ground_station")
 
-        self.rf_sensor._process(packet)
-        self.rf_sensor.buffer.put.assert_called_once_with(packet)
+        self.rf_sensor._process(self.packet)
+        buffer_mock.put.assert_called_once_with(self.packet)
 
         # RSSI broadcast packets must raise an exception on the ground station.
-        packet = Packet()
-        packet.set("specification", "rssi_broadcast")
+        self.packet.set("specification", "rssi_broadcast")
 
         with self.assertRaises(ValueError):
-            self.rf_sensor._process(packet)
+            self.rf_sensor._process(self.packet)
 
         # RSSI ground station packets must raise an exception on other RF sensors.
         self.rf_sensor._id = 1
 
-        packet = Packet()
-        packet.set("specification", "rssi_ground_station")
+        self.packet.set("specification", "rssi_ground_station")
 
         with self.assertRaises(ValueError):
-            self.rf_sensor._process(packet)
+            self.rf_sensor._process(self.packet)
 
     def test_process_rssi_broadcast_packet(self):
         timestamp = self.rf_sensor._scheduler.timestamp

--- a/tests/zigbee_rf_sensor_physical_texas_instruments.py
+++ b/tests/zigbee_rf_sensor_physical_texas_instruments.py
@@ -110,11 +110,12 @@ class TestZigBeeRFSensorPhysicalTexasInstruments(ZigBeeRFSensorTestCase, USBMana
                     usb_manager_mock.get_cc2530_device.assert_called_once_with()
                     self.assertEqual(self.rf_sensor._connection, connection_mock)
 
-                    wiringpi_mock.pinMode.assert_called_once_with(self.settings.get("reset_pin"),
+                    reset_pin = self.settings.get("reset_pin")
+                    wiringpi_mock.pinMode.assert_called_once_with(reset_pin,
                                                                   wiringpi_mock.OUTPUT)
-                    wiringpi_mock.digitalWrite.assert_any_call(self.settings.get("reset_pin"), 0)
-                    sleep_mock.assert_called_once_with(self.settings.get("reset_delay"))
-                    wiringpi_mock.digitalWrite.assert_any_call(self.settings.get("reset_pin"), 1)
+                    wiringpi_mock.digitalWrite.assert_any_call(reset_pin, 0)
+                    sleep_mock.assert_any_call(self.settings.get("reset_delay"))
+                    wiringpi_mock.digitalWrite.assert_any_call(reset_pin, 1)
                     self.assertEqual(wiringpi_mock.digitalWrite.call_count, 2)
 
                     connection_mock.reset_input_buffer.assert_called_once_with()

--- a/tests/zigbee_rf_sensor_physical_texas_instruments.py
+++ b/tests/zigbee_rf_sensor_physical_texas_instruments.py
@@ -7,9 +7,7 @@ import time
 from mock import call, patch, MagicMock
 
 # Package imports
-from ..core.Thread_Manager import Thread_Manager
 from ..core.WiringPi import WiringPi
-from ..settings.Arguments import Arguments
 from ..zigbee.Packet import Packet
 from ..zigbee.RF_Sensor import DisabledException
 from ..zigbee.RF_Sensor_Physical_Texas_Instruments import RF_Sensor_Physical_Texas_Instruments
@@ -17,28 +15,17 @@ from ..zigbee.RF_Sensor_Physical_Texas_Instruments import CC2530_Packet, Raspber
 from ..zigbee.TDMA_Scheduler import TDMA_Scheduler
 from core_wiringpi import WiringPiTestCase
 from core_usb_manager import USBManagerTestCase
-from settings import SettingsTestCase
+from zigbee_rf_sensor import ZigBeeRFSensorTestCase
 
-class TestZigBeeRFSensorPhysicalTexasInstruments(SettingsTestCase, USBManagerTestCase, WiringPiTestCase):
+class TestZigBeeRFSensorPhysicalTexasInstruments(ZigBeeRFSensorTestCase, USBManagerTestCase, WiringPiTestCase):
     def setUp(self):
         super(TestZigBeeRFSensorPhysicalTexasInstruments, self).setUp()
 
-        self.arguments = Arguments("settings.json", ["--rf-sensor-id", "1"])
         self.settings = self.arguments.get_settings("rf_sensor_physical_texas_instruments")
-
-        self.thread_manager = Thread_Manager()
-        self.location_callback = MagicMock(return_value=((0, 0), 0))
-        self.receive_callback = MagicMock()
-        self.valid_callback = MagicMock(return_value=True)
-
         self.usb_manager.index()
 
-        self.rf_sensor = RF_Sensor_Physical_Texas_Instruments(self.arguments,
-                                                              self.thread_manager,
-                                                              self.location_callback,
-                                                              self.receive_callback,
-                                                              self.valid_callback,
-                                                              usb_manager=self.usb_manager)
+        self.rf_sensor = self._create_sensor(RF_Sensor_Physical_Texas_Instruments,
+                                             usb_manager=self.usb_manager)
 
     def test_initialization(self):
         self.assertEqual(self.rf_sensor._address, str(self.rf_sensor.id))
@@ -60,76 +47,77 @@ class TestZigBeeRFSensorPhysicalTexasInstruments(SettingsTestCase, USBManagerTes
         # The `type` property must be implemented and correct.
         self.assertEqual(self.rf_sensor.type, "rf_sensor_physical_texas_instruments")
 
-    def test_activate(self):
-        self.rf_sensor._synchronize = MagicMock()
-
+    @patch.object(RF_Sensor_Physical_Texas_Instruments, "_synchronize")
+    def test_activate(self, synchronize_mock):
         with patch.object(RF_Sensor_Physical_Texas_Instruments, "_setup"):
             with patch.object(thread, "start_new_thread"):
                 self.rf_sensor.activate()
-                self.rf_sensor._synchronize.assert_called_once_with()
+                synchronize_mock.assert_called_once_with()
 
-    def test_discover(self):
-        with patch.object(RF_Sensor_Physical_Texas_Instruments, "_send_tx_frame") as send_tx_frame_mock:
-            self.rf_sensor.discover(MagicMock())
+    @patch.object(RF_Sensor_Physical_Texas_Instruments, "_send_tx_frame")
+    def test_discover(self, send_tx_frame_mock):
+        self.rf_sensor.discover(MagicMock())
 
-            calls = send_tx_frame_mock.call_args_list
+        calls = send_tx_frame_mock.call_args_list
 
-            # Ping/pong packets must be sent to all sensors in the network.
-            for to_id in xrange(1, self.rf_sensor.number_of_sensors + 1):
-                packet, to = calls.pop(0)[0]
-                self.assertIsInstance(packet, Packet)
-                self.assertEqual(packet.get("specification"), "ping_pong")
-                self.assertEqual(packet.get("sensor_id"), to_id)
-                self.assertEqual(to, to_id)
+        # Ping/pong packets must be sent to all sensors in the network.
+        for to_id in xrange(1, self.rf_sensor.number_of_sensors + 1):
+            packet, to = calls.pop(0)[0]
+            self.assertIsInstance(packet, Packet)
+            self.assertEqual(packet.get("specification"), "ping_pong")
+            self.assertEqual(packet.get("sensor_id"), to_id)
+            self.assertEqual(to, to_id)
 
     @patch.object(time, "sleep")
     def test_setup(self, sleep_mock):
         connection_mock = MagicMock()
-        usb_manager_mock = MagicMock(return_value=connection_mock)
-
-        # The ground station must be a CC2531 device and it must be configured.
-        self.rf_sensor._id = 0
-        self.rf_sensor._usb_manager.get_cc2531_device = usb_manager_mock
-        self.rf_sensor._setup()
-        self.rf_sensor._usb_manager.get_cc2531_device.assert_called_once_with()
-        self.assertEqual(self.rf_sensor._connection, connection_mock)
-
-        configuration_packet = struct.pack("<BB", CC2530_Packet.CONFIGURATION, self.rf_sensor.id)
-        connection_mock.write.assert_called_once_with(configuration_packet)
-
-        # Other RF sensors must be connected to a Raspberry Pi device.
-        self.rf_sensor._id = 1
-        with self.assertRaises(RuntimeError):
+        methods = {
+            "get_cc2530_device.return_value": connection_mock,
+            "get_cc2531_device.return_value": connection_mock
+        }
+        with patch.object(self.rf_sensor, "_usb_manager", **methods) as usb_manager_mock:
+            # The ground station must be a CC2531 device and its connection 
+            # must be established and configured.
+            self.rf_sensor._id = 0
             self.rf_sensor._setup()
+            usb_manager_mock.get_cc2531_device.assert_called_once_with()
+            self.assertEqual(self.rf_sensor._connection, connection_mock)
 
-        # Other RF sensors must be CC2530 devices and they must be configured.
-        connection_mock.reset_mock()
-        usb_manager_mock.reset_mock()
+            configuration_packet = struct.pack("<BB", CC2530_Packet.CONFIGURATION, self.rf_sensor.id)
+            connection_mock.write.assert_called_once_with(configuration_packet)
 
-        with patch.object(WiringPi, "is_raspberry_pi", return_value=True):
-            with patch.object(WiringPi, "module") as wiringpi_mock:
-                self.rf_sensor._usb_manager.get_cc2530_device = usb_manager_mock
-
+            # Other RF sensors must be connected to a Raspberry Pi device.
+            self.rf_sensor._id = 1
+            with self.assertRaises(RuntimeError):
                 self.rf_sensor._setup()
 
-                wiringpi_mock.pinModeAlt.assert_has_calls([
-                    call(self.settings.get("rx_pin"), Raspberry_Pi_GPIO_Pin_Mode.ALT0),
-                    call(self.settings.get("tx_pin"), Raspberry_Pi_GPIO_Pin_Mode.ALT0),
-                    call(self.settings.get("rts_pin"), Raspberry_Pi_GPIO_Pin_Mode.ALT3),
-                    call(self.settings.get("cts_pin"), Raspberry_Pi_GPIO_Pin_Mode.ALT3)
-                ])
+            # Other RF sensors must be CC2530 devices and they must be 
+            # configured.
+            connection_mock.reset_mock()
+            usb_manager_mock.reset_mock()
 
-                self.rf_sensor._usb_manager.get_cc2530_device.assert_called_once_with()
-                self.assertEqual(self.rf_sensor._connection, connection_mock)
+            with patch.object(WiringPi, "is_raspberry_pi", return_value=True):
+                with patch.object(WiringPi, "module") as wiringpi_mock:
+                    self.rf_sensor._setup()
 
-                wiringpi_mock.pinMode.assert_called_once_with(self.settings.get("reset_pin"),
-                                                              wiringpi_mock.OUTPUT)
-                wiringpi_mock.digitalWrite.assert_any_call(self.settings.get("reset_pin"), 0)
-                sleep_mock.assert_called_once_with(self.settings.get("reset_delay"))
-                wiringpi_mock.digitalWrite.assert_any_call(self.settings.get("reset_pin"), 1)
-                self.assertEqual(wiringpi_mock.digitalWrite.call_count, 2)
+                    wiringpi_mock.pinModeAlt.assert_has_calls([
+                        call(self.settings.get("rx_pin"), Raspberry_Pi_GPIO_Pin_Mode.ALT0),
+                        call(self.settings.get("tx_pin"), Raspberry_Pi_GPIO_Pin_Mode.ALT0),
+                        call(self.settings.get("rts_pin"), Raspberry_Pi_GPIO_Pin_Mode.ALT3),
+                        call(self.settings.get("cts_pin"), Raspberry_Pi_GPIO_Pin_Mode.ALT3)
+                    ])
 
-                connection_mock.reset_input_buffer.assert_called_once_with()
+                    usb_manager_mock.get_cc2530_device.assert_called_once_with()
+                    self.assertEqual(self.rf_sensor._connection, connection_mock)
+
+                    wiringpi_mock.pinMode.assert_called_once_with(self.settings.get("reset_pin"),
+                                                                  wiringpi_mock.OUTPUT)
+                    wiringpi_mock.digitalWrite.assert_any_call(self.settings.get("reset_pin"), 0)
+                    sleep_mock.assert_called_once_with(self.settings.get("reset_delay"))
+                    wiringpi_mock.digitalWrite.assert_any_call(self.settings.get("reset_pin"), 1)
+                    self.assertEqual(wiringpi_mock.digitalWrite.call_count, 2)
+
+                    connection_mock.reset_input_buffer.assert_called_once_with()
 
     def test_loop_body(self):
         # Shifting the schedule must be handled.
@@ -157,86 +145,87 @@ class TestZigBeeRFSensorPhysicalTexasInstruments(SettingsTestCase, USBManagerTes
             receive_mock.assert_called_once_with()
 
     def test_send_tx_frame(self):
-        packet = Packet()
-        packet.set("specification", "waypoint_clear")
-        packet.set("to_id", 2)
+        self.packet.set("specification", "waypoint_clear")
+        self.packet.set("to_id", 2)
 
-        self.rf_sensor._connection = MagicMock()
+        with patch.object(self.rf_sensor, "_connection") as connection_mock:
+            self.rf_sensor._send_tx_frame(self.packet, to=2)
 
-        self.rf_sensor._send_tx_frame(packet, to=2)
+            # The packet must be sent over the serial connection. The packet is 
+            # serialized using the struct format "BBB80s", i.e., three 
+            # characters and a string padded to 80 (packet length setting) 
+            # bytes. We add the padding manually here.
+            serialized_packet = "\x02\x02\x02\x05\x02{}".format("\x00" * 78)
+            connection_mock.write.assert_called_once_with(serialized_packet)
+            connection_mock.flush.assert_called_once_with()
 
-        # The packet must be sent over the serial connection. The packet is serialized
-        # using the struct format "BBB80s", i.e., three characters and a string padded
-        # to 80 (packet length setting) bytes. We add the padding manually here.
-        serialized_packet = "\x02\x02\x02\x05\x02{}".format("\x00" * 78)
-        self.rf_sensor._connection.write.assert_called_once_with(serialized_packet)
-        self.rf_sensor._connection.flush.assert_called_once_with()
+    @patch.object(RF_Sensor_Physical_Texas_Instruments, "_process")
+    def test_receive(self, process_mock):
+        with patch.object(self.rf_sensor, "_connection") as connection_mock:
+            # Nothing should be done when there is not enough data in the 
+            # serial buffer.
+            connection_mock.in_waiting = 0
+            self.rf_sensor._receive()
+            connection_mock.read.assert_not_called()
 
-    def test_receive(self):
-        # Nothing should be done when there is not enough data in the serial buffer.
-        self.rf_sensor._connection = MagicMock()
-        self.rf_sensor._connection.in_waiting = 0
-        self.rf_sensor._receive()
-        self.rf_sensor._connection.read.assert_not_called()
+            # Create the `Packet` object for processing if there is enough data 
+            # in the serial buffer.
+            serialized_packet = "\x02\x05\x02{}\x2A".format("\x00" * 78)
+            connection_mock.in_waiting = len(serialized_packet)
+            connection_mock.read.configure_mock(return_value=serialized_packet)
 
-        # Create the `Packet` object if there is enough data in the serial buffer.
-        serialized_packet = "\x02\x05\x02{}\x2A".format("\x00" * 78)
-        self.rf_sensor._connection.in_waiting = len(serialized_packet)
-        self.rf_sensor._connection.read.configure_mock(return_value=serialized_packet)
-        self.rf_sensor._process = MagicMock()
+            self.rf_sensor._receive()
 
-        self.rf_sensor._receive()
+            self.assertTrue(self.rf_sensor._other_packet_received)
 
-        self.assertTrue(self.rf_sensor._other_packet_received)
+            arguments = process_mock.call_args[0]
+            keyword_arguments = process_mock.call_args[1]
+            self.assertIsInstance(arguments[0], Packet)
+            self.assertEqual(arguments[0].get_all(), {
+                "specification": "waypoint_clear",
+                "to_id": 2
+            })
+            self.assertEqual(keyword_arguments["rssi"], 42)
 
-        arguments = self.rf_sensor._process.call_args[0]
-        keyword_arguments = self.rf_sensor._process.call_args[1]
-        self.assertIsInstance(arguments[0], Packet)
-        self.assertEqual(arguments[0].get_all(), {
-            "specification": "waypoint_clear",
-            "to_id": 2
-        })
-        self.assertEqual(keyword_arguments["rssi"], 42)
-
-    def test_process(self):
+    @patch.object(RF_Sensor_Physical_Texas_Instruments, "_process_rssi_broadcast_packet")
+    def test_process(self, process_rssi_broadcast_packet_mock):
         # RSSI value must be provided.
         with self.assertRaises(TypeError):
             self.rf_sensor._process(Packet())
 
-        self.rf_sensor._process_rssi_broadcast_packet = MagicMock()
-
         # Ping/pong packets must be handled on the ground station.
-        self.rf_sensor._discovery_callback = MagicMock()
-        self.rf_sensor._id = 0
+        with patch.object(self.rf_sensor, "_discovery_callback") as discovery_callback_mock:
+            self.rf_sensor._id = 0
 
-        packet = Packet()
-        packet.set("specification", "ping_pong")
-        packet.set("sensor_id", 2)
+            packet = Packet()
+            packet.set("specification", "ping_pong")
+            packet.set("sensor_id", 2)
 
-        self.rf_sensor._process(packet, rssi=42)
-        self.rf_sensor._discovery_callback.assert_called_once_with({
-            "id": packet.get("sensor_id"),
-            "address": str(packet.get("sensor_id"))
-        })
-        self.rf_sensor._process_rssi_broadcast_packet.assert_not_called()
+            self.rf_sensor._process(packet, rssi=42)
+            discovery_callback_mock.assert_called_once_with({
+                "id": packet.get("sensor_id"),
+                "address": str(packet.get("sensor_id"))
+            })
+            process_rssi_broadcast_packet_mock.assert_not_called()
 
         # Other RF sensors must respond to ping/pong packets.
-        self.rf_sensor._send_tx_frame = MagicMock()
-        self.rf_sensor._id = 1
+        with patch.object(self.rf_sensor, "_send_tx_frame") as send_tx_frame_mock:
+            self.rf_sensor._id = 1
 
-        packet = Packet()
-        packet.set("specification", "ping_pong")
+            packet = Packet()
+            packet.set("specification", "ping_pong")
 
-        self.rf_sensor._process(packet, rssi=42)
-        self.rf_sensor._send_tx_frame.assert_called_once_with(packet, 0)
-        self.rf_sensor._process_rssi_broadcast_packet.assert_not_called()
+            self.rf_sensor._process(packet, rssi=42)
+            send_tx_frame_mock.assert_called_once_with(packet, 0)
+            process_rssi_broadcast_packet_mock.assert_not_called()
 
         # Other RF sensors must handle RSSI broadcast packets.
         packet = Packet()
         packet.set("specification", "rssi_broadcast")
 
         self.rf_sensor._process(packet, rssi=42)
-        self.rf_sensor._process_rssi_broadcast_packet.assert_called_once_with(packet, rssi=42)
+        process_rssi_broadcast_packet_mock.assert_called_once_with(packet,
+                                                                   rssi=42)
 
     def test_process_rssi_broadcast_packet(self):
         # RSSI value must be provided.

--- a/tests/zigbee_xbee_configurator.py
+++ b/tests/zigbee_xbee_configurator.py
@@ -1,5 +1,5 @@
 import serial
-from mock import MagicMock
+from mock import patch, MagicMock
 from ..core.USB_Manager import USB_Device_Baud_Rate
 from ..zigbee.XBee_Configurator import XBee_Configurator, XBee_Response_Status
 from ..settings import Arguments
@@ -14,7 +14,9 @@ class TestZigBeeXBeeConfigurator(USBManagerTestCase, SettingsTestCase):
         self.settings = self.arguments.get_settings("xbee_configurator")
 
         self.usb_manager.index()
-        self.configurator = XBee_Configurator(self.settings, self.usb_manager)
+        with patch("time.sleep"):
+            self.configurator = XBee_Configurator(self.settings,
+                                                  self.usb_manager)
 
         # Mock the sensor as we cannot test with the actual hardware.
         self.configurator._sensor = MagicMock()

--- a/vehicle/MAVLink_Vehicle.py
+++ b/vehicle/MAVLink_Vehicle.py
@@ -7,13 +7,17 @@ class MAVLink_Vehicle(Vehicle):
     A vehicle that supports some parts of the MAVLink protocol, e.g.,
     mission command sequences or other command message parsing.
 
-    This class assumes the following properties and methods exist:
+    In addition to the interface enforced by `Vehicle`, this class requires that
+    the following properties and methods exist with semantics:
     - `commands`: A `CommandSequence`-like object, as described in
       http://python.dronekit.io/automodule.html#dronekit.CommandSequence
     - `flush`: A method that might perform backend changes for update_mission,
       but can also be a no-op if no backend changes are necessary in this case.
+    - `location`: A read-only property, that returns the current location of
+      the vehicle as a `Locations` object. Other types are not allowed, although
+      the returned `Locations` may have frames with invalid locations.
 
-    Also, all abstract methods from `Vehicle` must also be implemented.
+    Of course, all abstract methods from `Vehicle` must also be implemented.
     """
 
     @property

--- a/vehicle/MAVLink_Vehicle.py
+++ b/vehicle/MAVLink_Vehicle.py
@@ -1,7 +1,6 @@
-from dronekit import LocationLocal, LocationGlobalRelative, Command
+from dronekit import LocationLocal, Command
 from pymavlink import mavutil
 from Vehicle import Vehicle
-from ..geometry.Geometry_Spherical import Geometry_Spherical
 
 class MAVLink_Vehicle(Vehicle):
     """
@@ -83,10 +82,7 @@ class MAVLink_Vehicle(Vehicle):
         lat = mission_item.x
         lon = mission_item.y
         alt = mission_item.z
-        if isinstance(self._geometry, Geometry_Spherical):
-            return LocationGlobalRelative(lat, lon, alt)
-
-        return LocationLocal(lat, lon, -alt)
+        return self._geometry.make_location(lat, lon, alt)
 
     def get_next_waypoint(self):
         return self.commands.next
@@ -101,7 +97,5 @@ class MAVLink_Vehicle(Vehicle):
         return self.commands.count
 
     def is_current_location_valid(self):
-        if isinstance(self._geometry, Geometry_Spherical):
-            return self.is_location_valid(self.location.global_relative_frame)
-
-        return self.is_location_valid(self.location.local_frame)
+        location = self._geometry.get_location_frame(self.location)
+        return self.is_location_valid(location)

--- a/vehicle/Mock_Vehicle.py
+++ b/vehicle/Mock_Vehicle.py
@@ -245,7 +245,7 @@ class Mock_Vehicle(MAVLink_Vehicle):
 
         if location is not None:
             # Track the target location and convert it so that the remainder of 
-            # this method can use global relative frame locations.
+            # this method can use global (relative) frame locations.
             self._target_location = location
             target_location = self._make_global_location(location)
         else:
@@ -261,9 +261,12 @@ class Mock_Vehicle(MAVLink_Vehicle):
             self._target_location = self._make_location(LocationGlobalRelative,
                                                         lat, lon, alt)
 
-        # Change yaw to go to new target location
-        if self._location.lat == target_location.lat and self._location.lon == target_location.lon:
-            # Moving straight up/down does not require any angle change
+        # Decide which yaw we need to go to new target location.
+        current_coords = (self._location.lat, self._location.lon)
+        target_coords = (target_location.lat, target_location.lon)
+        if current_coords == target_coords:
+            # Moving straight up/down, i.e., no difference in latitude and 
+            # longitude, does not require any yaw angle change.
             yaw = self._attitude._yaw
         else:
             a = self._geometry.get_angle(self._locations, self._target_location)

--- a/vehicle/Mock_Vehicle.py
+++ b/vehicle/Mock_Vehicle.py
@@ -600,10 +600,10 @@ class Mock_Vehicle(MAVLink_Vehicle):
     def _make_location(self, location_class, lat, lon, alt):
         if isinstance(self._geometry, Geometry_Spherical):
             return location_class(lat, lon, alt)
-        else:
-            return LocationLocal(lat - self._home_location.lat,
-                                 lon - self._home_location.lon,
-                                 self._home_location.alt - alt)
+
+        return LocationLocal(lat - self._home_location.lat,
+                             lon - self._home_location.lon,
+                             self._home_location.alt - alt)
 
     def flush(self):
         pass

--- a/vehicle/Robot_Vehicle.py
+++ b/vehicle/Robot_Vehicle.py
@@ -4,7 +4,7 @@ import thread
 import time
 
 # Library imports
-from dronekit import LocationLocal, LocationGlobal, Attitude
+from dronekit import LocationLocal, Attitude
 import numpy as np
 
 # Package imports
@@ -192,15 +192,12 @@ class Robot_Vehicle(Vehicle):
 
     @property
     def home_location(self):
-        return LocationGlobal(0.0, 0.0, 0.0)
+        return self._geometry.make_location(*self._home_location)
 
     @home_location.setter
     def home_location(self, value):
-        if isinstance(value, LocationLocal):
-            self._home_location = (value.north, value.east)
-        else:
-            print("Warning: Using non-local locations")
-            self._home_location = (value.lat, value.lon)
+        self._home_location = self._geometry.get_coordinates(value)[:2]
+        self.notify_attribute_listeners("home_location", self.home_location)
 
     @property
     def mode(self):
@@ -247,11 +244,7 @@ class Robot_Vehicle(Vehicle):
                 self._line_follower.deactivate()
 
     def add_waypoint(self, location):
-        if isinstance(location, LocationLocal):
-            self._waypoints.append((location.north, location.east))
-        else:
-            print("Warning: Using non-local locations")
-            self._waypoints.append((location.lat, location.lon))
+        self._waypoints.append(self._geometry.get_coordinates(location)[:2])
 
     def add_wait(self):
         self._waypoints.append(None)

--- a/vehicle/Vehicle.py
+++ b/vehicle/Vehicle.py
@@ -73,16 +73,23 @@ class Vehicle(Threadable):
         """
         Retrieve the home location object.
 
-        This property returns a fresh `Location` object.
-        Depending on the vehicle, the frame of the location may differ.
+        This property returns a fresh `Location` object. The location type can
+        depend on the vehicle type and the vehicle's geometry.
         """
 
-        return None
+        raise NotImplementedError("Subclasses must implement `home_location` property")
 
     @home_location.setter
     def home_location(self, position):
         """
         Change the home location to another `Location` object.
+
+        The location `position` need not be a `LocationGlobal` object, but exact
+        handling of other types may depend on the vehicle type and the vehicle's
+        geometry.
+
+        An updated location also results in a notification to the attribute
+        listeners with a fresh `Location` object.
         """
 
         self._home_location = copy.copy(position)
@@ -285,8 +292,9 @@ class Vehicle(Threadable):
         """
         Retrieve the current location of the vehicle.
 
-        This property returns the location as a `Locations` object or one of
-        the `LocationGlobal`, `LocalGlobalRelative` or `LocationLocal` objects.
+        This property returns the location as a `Locations` object with any
+        number of valid frames, or one of the `LocationLocal`,
+        `LocationGlobalRelative` or `LocationGlobal` objects.
         """
 
         raise NotImplementedError("Subclasses must implement `location` property")

--- a/zigbee/specifications.json
+++ b/zigbee/specifications.json
@@ -135,6 +135,10 @@
             "format": "B"
         },
         {
+            "name": "wait_count",
+            "format": "i"
+        },
+        {
             "name": "index",
             "format": "i"
         },


### PR DESCRIPTION
- Update geometry interface.
- Support wait count to determine how often we want to wait and synchronize between two waypoints. Both the vehicle mission and control panel waypoints view fully support it (along with a compression algorithm).
- Updates to tests.
