### PR TITLE
Update files to conform to Pylint upgrade

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+default_section=LOCALFOLDER

--- a/control_panel/Control_Panel_Planning_View.py
+++ b/control_panel/Control_Panel_Planning_View.py
@@ -4,10 +4,15 @@ import pyqtgraph as pg
 
 # matplotlib imports
 import matplotlib
-matplotlib.use("Qt4Agg")
+try:
+    matplotlib.use("Qt4Agg")
+except ValueError as e:
+    raise ImportError("Could not load matplotlib backend: {}".format(e.message))
+finally:
+    import matplotlib.pyplot as plt
+
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.lines import Line2D
-import matplotlib.pyplot as plt
 
 # Package imports
 from Control_Panel_View import Control_Panel_View, Control_Panel_View_Name

--- a/control_panel/Control_Panel_Reconstruction_View.py
+++ b/control_panel/Control_Panel_Reconstruction_View.py
@@ -5,8 +5,13 @@ import os
 
 # matplotlib imports
 import matplotlib
-matplotlib.use("Qt4Agg")
-import matplotlib.pyplot as plt
+try:
+    matplotlib.use("Qt4Agg")
+except ValueError as e:
+    raise ImportError("Could not load matplotlib backend: {}".format(e.message))
+finally:
+    import matplotlib.pyplot as plt
+
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 
 # NumPy imports

--- a/control_panel/Control_Panel_View.py
+++ b/control_panel/Control_Panel_View.py
@@ -3,8 +3,12 @@ from PyQt4 import QtCore, QtGui
 
 # matplotlib imports
 import matplotlib
-matplotlib.use("Qt4Agg")
-import matplotlib.pyplot as plt
+try:
+    matplotlib.use("Qt4Agg")
+except ValueError as e:
+    raise ImportError("Could not load matplotlib backend: {}".format(e.message))
+finally:
+    import matplotlib.pyplot as plt
 
 class Control_Panel_View_Name(object):
     LOADING = 0

--- a/plan_reconstruct.py
+++ b/plan_reconstruct.py
@@ -6,9 +6,13 @@ import json
 
 # matplotlib imports
 import matplotlib
-# Make it possible to run matplotlib in displayless (console-only) mode
-matplotlib.use('Agg' if 'DISPLAY' not in os.environ or os.environ['DISPLAY'] == '' else matplotlib.get_backend())
-import matplotlib.pyplot as plt
+try:
+    # Make it possible to run matplotlib in displayless (console-only) mode
+    matplotlib.use('Agg' if 'DISPLAY' not in os.environ or os.environ['DISPLAY'] == '' else matplotlib.get_backend())
+except ValueError as e:
+    raise ImportError("Could not load matplotlib backend: {}".format(e.message))
+finally:
+    import matplotlib.pyplot as plt
 
 # Package imports
 from __init__ import __package__

--- a/zigbee/RF_Sensor_Physical_XBee.py
+++ b/zigbee/RF_Sensor_Physical_XBee.py
@@ -189,8 +189,10 @@ class RF_Sensor_Physical_XBee(RF_Sensor_Physical):
 
             self._send_tx_frame(packet, to_id)
 
-        # Send collected packets to the ground station.
-        for frame_id in self._packets.keys():
+        # Send collected packets to the ground station. Only send completed 
+        # packets, and remove them after sending. We have to iterate over 
+        # a copy to avoid changing the dictionary during iteration.
+        for frame_id in self._packets.copy():
             packet = self._packets[frame_id]
             if packet.get("rssi") is None:
                 continue


### PR DESCRIPTION
A new version of pylint, 1.6.1, was pushed to the pip package index on
2016-07-07, which requires some changes to conform to the lint checks.
- Pylint now uses the isort module to determine whether modules are
  imported in the correct order. The plugin we have is still necessary
  for other cases where the checker wants to know if something is
  a standard module. Make isort default to 'local folder' import section
  when it cannot determine the import source, so that tests that import
  base test cases locally work without arcane dotted syntax.
- In some way, Pylint has become more strict about mixing function calls
  between top import statements. This means that `matplotlib.use`, which
  needs to be done after `matplotlib` but before `matplotlib.pyplot` is
  imported, receives a convention warning. Wrap it into a try..except
  that converts the `ValueError` to `ImportError`, and has a finally
  block that imports `pyplot` to let pylint know that it is an import
  "statement".
- `RF_Sensor_Physical_XBee`: pylint recommends not iterating over the
  keys of a dictionary using `keys`, since iterating over the dict
  itself gives us the keys. Instead iterate over a copy, which makes
  this code more fool-proof for Python 3. Mention why we need to use
  a copy to avoid a "dictionary changed during iteration" exception, and
  explain why the loop only removes some of the packets along the way.
