### PR TITLE
Vehicle pause

### DIFF
--- a/control/remotes/Sony_RM-SRB5.lircrc
+++ b/control/remotes/Sony_RM-SRB5.lircrc
@@ -5,6 +5,12 @@ begin
 end
 
 begin
+    button = cd_pause
+    prog = mobile-radio-tomography
+    config = pause
+end
+
+begin
     button = cd_stop
     prog = mobile-radio-tomography
     config = stop

--- a/mission_basic.py
+++ b/mission_basic.py
@@ -42,6 +42,7 @@ class Setup(object):
         infrared_sensor = self.environment.get_infrared_sensor()
         if infrared_sensor is not None:
             infrared_sensor.register("start", self.enable)
+            infrared_sensor.register("pause", self.monitor.pause)
             infrared_sensor.register("stop", self._infrared_disable)
             infrared_sensor.activate()
         else:

--- a/rf_sensor.py
+++ b/rf_sensor.py
@@ -42,11 +42,22 @@ def main(argv):
 
     try:
         rf_sensor.activate()
-        raw_input("RF sensor has joined the network. Press Enter to continue...")
-        rf_sensor.start()
 
+        print("RF sensor has joined the network.")
         while True:
-            time.sleep(1)
+            if rf_sensor.id == 0:
+                # The ground station does not need to start in order to receive 
+                # measurements, so do not bother giving this possibility.
+                time.sleep(1)
+            else:
+                # Wait for the user to determine when to perform measurements 
+                # and when to stop. Add a newline so that the messages do not 
+                # mess up other output.
+                raw_input("Press Enter to start measurements...\n")
+                rf_sensor.start()
+
+                raw_input("Press Enter to stop measurements...\n")
+                rf_sensor.stop()
     except:
         traceback.print_exc()
         thread_manager.destroy()

--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -358,6 +358,12 @@
                 "help": "Whether to display a viewer of the current vehicle's sight (requires pyglet and a simulated environment)",
                 "type": "bool",
                 "default": true
+            },
+            "plot_sensor_colors": {
+                "help": "Color names to use for the selected edges by different sensors in the memory map plot during simulation",
+                "type": "list",
+                "subtype": "string",
+                "default": ["red", "purple", "black"]
             }
         }
     },

--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -193,7 +193,7 @@
                 "help": "Registered buttons",
                 "type": "list",
                 "subtype": "string",
-                "default": ["start", "stop", "up", "down", "left", "right"]
+                "default": ["start", "pause", "stop", "up", "down", "left", "right"]
             },
             "wait_delay": {
                 "help": "Delay in seconds for the infrared sensor thread",

--- a/tests/vehicle.py
+++ b/tests/vehicle.py
@@ -71,7 +71,7 @@ class TestVehicle(VehicleTestCase):
         self.assertTrue(hasattr(self.vehicle, "_attribute_listeners"))
 
     @covers([
-        "setup", "update_mission", "add_takeoff", "add_waypoint",
+        "setup", "pause", "update_mission", "add_takeoff", "add_waypoint",
         "clear_waypoints", "add_wait", "is_wait", "get_waypoint",
         "get_next_waypoint", "set_next_waypoint", "count_waypoints",
         "check_arming", "simple_takeoff", "simple_goto", "set_yaw", "set_servo"
@@ -84,6 +84,10 @@ class TestVehicle(VehicleTestCase):
             dummy = self.vehicle.home_location
 
         self.vehicle.setup()
+
+        with self.assertRaises(NotImplementedError):
+            self.vehicle.pause()
+
         self.vehicle.update_mission()
 
         self.assertFalse(self.vehicle.add_takeoff(42))

--- a/tests/vehicle_mock_vehicle.py
+++ b/tests/vehicle_mock_vehicle.py
@@ -328,6 +328,17 @@ class TestVehicleMockVehicle(VehicleTestCase):
         self.vehicle.clear_target_location()
         self.assertIsNone(self.vehicle._target_location)
 
+    def test_pause(self):
+        with patch.object(Mock_Vehicle, "_get_delta_time") as delta_mock:
+            self.vehicle.check_arming()
+            self.vehicle.armed = True
+
+            self.vehicle.pause()
+            self.assertEqual(self.vehicle.mode.name, "PAUSE")
+
+            self.vehicle.update_location()
+            delta_mock.assert_not_called()
+
     def test_update_location_speed(self):
         with patch.object(Mock_Vehicle, "_get_delta_time", return_value=(1.0, 1234567890.123)) as delta_mock:
             self.vehicle.update_location()

--- a/tests/vehicle_robot_vehicle.py
+++ b/tests/vehicle_robot_vehicle.py
@@ -153,10 +153,6 @@ class TestVehicleRobotVehicle(RobotVehicleTestCase):
         self.assertEqual(self.vehicle.mode.name, "HALT")
         self.assertFalse(self.vehicle.armed)
 
-        self.vehicle.mode = VehicleMode("GUIDED")
-        self.assertEqual(self.vehicle.mode.name, "GUIDED")
-        self.assertTrue(self.vehicle.armed)
-
     @patch('thread.start_new_thread')
     def test_unpause(self, thread_mock):
         self.vehicle.activate()

--- a/tests/vehicle_robot_vehicle_arduino.py
+++ b/tests/vehicle_robot_vehicle_arduino.py
@@ -47,10 +47,24 @@ class TestVehicleRobotVehicleArduino(RobotVehicleTestCase):
             thread_mock.assert_any_call(self.vehicle._state_loop, ())
 
     def test_deactivate(self):
-        with patch.object(Threadable, "deactivate"):
-            self.vehicle.deactivate()
-            # Reset signal is at high level on the DTR line.
-            self.assertTrue(self.vehicle._serial_connection.dtr)
+        with patch.object(self.vehicle, "set_speeds") as set_speeds_mock:
+            with patch.object(Threadable, "deactivate"):
+                self.vehicle.deactivate()
+                set_speeds_mock.assert_called_once_with(0, 0)
+                # Reset signal is at high level on the DTR line.
+                self.assertTrue(self.vehicle._serial_connection.dtr)
+
+    def test_pause(self):
+        with patch.object(Threadable, "activate"):
+            self.vehicle.activate()
+
+        with patch.object(self.vehicle, "set_speeds") as set_speeds_mock:
+            with patch.object(Threadable, "deactivate"):
+                self.vehicle.pause()
+                set_speeds_mock.assert_called_once_with(0, 0)
+                # Reset signal is at low level on the DTR line, so not 
+                # resetting in this case.
+                self.assertFalse(self.vehicle._serial_connection.dtr)
 
     @patch.object(serial.Serial, "write")
     def test_set_speeds(self, write_mock):

--- a/tests/zigbee_rf_sensor.py
+++ b/tests/zigbee_rf_sensor.py
@@ -150,15 +150,23 @@ class TestZigBeeRFSensor(ZigBeeRFSensorTestCase):
 
     def test_start(self):
         # The sensor must be started for sending RSSI broadcast/ground
-        # station packets.
+        # station packets. Make sure that the schedule will try to shift again 
+        # when the measurements start.
         self.rf_sensor.start()
         self.assertTrue(self.rf_sensor._started)
         self.assertEqual(self.rf_sensor._packets, [])
+        self.assertNotEqual(self.rf_sensor._scheduler.timestamp, 0.0)
 
     def test_stop(self):
-        # The sensor must be stopped for sending custom packets.
+        # Pertent we start the RF sensor so that we know that `stop` functions.
+        self.rf_sensor.start()
+
+        # The sensor must be stopped for sending custom packets. Make sure that 
+        # the scheduler timestamp is reset, so that it updates correctly in 
+        # case we restart the sensor measurements.
         self.rf_sensor.stop()
         self.assertEqual(self.rf_sensor._started, False)
+        self.assertEqual(self.rf_sensor._scheduler.timestamp, 0.0)
 
     def test_enqueue(self):
         # Providing a packet that is not a `Packet` object raises an exception.

--- a/tests/zigbee_rf_sensor.py
+++ b/tests/zigbee_rf_sensor.py
@@ -158,7 +158,8 @@ class TestZigBeeRFSensor(ZigBeeRFSensorTestCase):
         self.assertNotEqual(self.rf_sensor._scheduler.timestamp, 0.0)
 
     def test_stop(self):
-        # Pertent we start the RF sensor so that we know that `stop` functions.
+        # Pretend that we start the RF sensor so that we know that `stop` 
+        # functions.
         self.rf_sensor.start()
 
         # The sensor must be stopped for sending custom packets. Make sure that 

--- a/tests/zigbee_rf_sensor_physical.py
+++ b/tests/zigbee_rf_sensor_physical.py
@@ -101,6 +101,8 @@ class TestZigBeeRFSensorPhysical(ZigBeeRFSensorTestCase):
             self.rf_sensor._process(self.packet)
 
     def test_process_rssi_broadcast_packet(self):
+        self.rf_sensor.start()
+
         timestamp = self.rf_sensor._scheduler.timestamp
 
         packet = self.rf_sensor._create_rssi_broadcast_packet()

--- a/tests/zigbee_rf_sensor_physical_texas_instruments.py
+++ b/tests/zigbee_rf_sensor_physical_texas_instruments.py
@@ -57,12 +57,8 @@ class TestZigBeeRFSensorPhysicalTexasInstruments(ZigBeeRFSensorTestCase, USBMana
                 synchronize_mock.assert_called_once_with()
 
     def test_start(self):
-        # The sensor must be started for sending RSSI broadcast/ground
-        # station packets. Make sure that the schedule will try to shift again 
-        # when the measurements start.
         self.rf_sensor.start()
         self.assertNotEqual(self.rf_sensor._polling_time, 0.0)
-        self.assertNotEqual(self.rf_sensor._scheduler.timestamp, 0.0)
 
     @patch.object(RF_Sensor_Physical_Texas_Instruments, "_send_tx_frame")
     def test_discover(self, send_tx_frame_mock):

--- a/tests/zigbee_rf_sensor_simulator.py
+++ b/tests/zigbee_rf_sensor_simulator.py
@@ -105,6 +105,8 @@ class TestZigBeeRFSensorSimulator(ZigBeeRFSensorTestCase):
                                                            address)
 
     def test_receive(self):
+        self.rf_sensor.start()
+
         # Not providing a packet raises an exception.
         with self.assertRaises(TypeError):
             self.rf_sensor._receive()

--- a/tests/zigbee_tdma_scheduler.py
+++ b/tests/zigbee_tdma_scheduler.py
@@ -42,8 +42,11 @@ class TestZigBeeTDMAScheduler(SettingsTestCase):
         self.assertEqual(self.scheduler.id, 1)
 
     def test_timestamp(self):
-        # It must be possible to get the timestamp for sending packets.
+        # It must be possible to get and set the timestamp for sending packets.
         self.assertEqual(self.scheduler.timestamp, 0)
+
+        self.scheduler.timestamp = 12345678.90
+        self.assertEqual(self.scheduler.timestamp, 12345678.90)
 
     def test_update(self):
         # The first time the method is called, the timestamp is based on the

--- a/trajectory/Monitor.py
+++ b/trajectory/Monitor.py
@@ -24,6 +24,7 @@ class Monitor(object):
 
         self.memory_map = None
         self.plot = None
+        self._paused = False
 
     def get_delay(self):
         return self.step_delay
@@ -51,6 +52,9 @@ class Monitor(object):
 
         Returns `Fase` if the loop should be halted.
         """
+
+        if self._paused:
+            return True
 
         # Put our current location on the map for visualization. Of course, 
         # this location is also "safe" since we are flying there.
@@ -109,6 +113,18 @@ class Monitor(object):
 
         if self.rf_sensor is not None:
             self.rf_sensor.start()
+
+    def pause(self):
+        if self._paused:
+            self.start()
+
+            self._paused = False
+        else:
+            self.environment.get_vehicle().pause()
+            if self.rf_sensor is not None:
+                self.rf_sensor.stop()
+
+            self._paused = True
 
     def stop(self):
         self.mission.stop()

--- a/trajectory/Monitor.py
+++ b/trajectory/Monitor.py
@@ -20,7 +20,7 @@ class Monitor(object):
         self.sensors = self.environment.get_distance_sensors()
         self.rf_sensor = self.environment.get_rf_sensor()
 
-        self.colors = ["red", "purple", "black"]
+        self.colors = self.settings.get("plot_sensor_colors")
 
         self.memory_map = None
         self.plot = None
@@ -50,7 +50,7 @@ class Monitor(object):
         `add_point` can be a callback function that accepts a Location object
         for a detected point from the distance sensors.
 
-        Returns `Fase` if the loop should be halted.
+        Returns `False` if the loop should be halted.
         """
 
         if self._paused:
@@ -115,6 +115,14 @@ class Monitor(object):
             self.rf_sensor.start()
 
     def pause(self):
+        """
+        Pause or unpause the mission.
+
+        If the mission is currently paused, then this restarts the mission in
+        the correct mode. Otherwise, the vehicle is paused and the RF sensor is
+        put in its passive mode.
+        """
+
         if self._paused:
             self.start()
 

--- a/vehicle/Dronekit_Vehicle.py
+++ b/vehicle/Dronekit_Vehicle.py
@@ -104,6 +104,14 @@ class Dronekit_Vehicle(dronekit.Vehicle, MAVLink_Vehicle):
 
         return True
 
+    def pause(self):
+        if self.is_rover:
+            self.mode = dronekit.VehicleMode("HOLD")
+        else:
+            self.mode = dronekit.VehicleMode("LOITER")
+
+        self.flush()
+
     def add_takeoff(self, altitude):
         if self.is_rover:
             return False

--- a/vehicle/Mock_Vehicle.py
+++ b/vehicle/Mock_Vehicle.py
@@ -395,7 +395,7 @@ class Mock_Vehicle(MAVLink_Vehicle):
         to speed or target locations immediately.
         """
 
-        if not self._takeoff or not self.armed:
+        if not self._takeoff or not self.armed or self._mode.name == "PAUSE":
             return
 
         diff, new_time = self._get_delta_time()
@@ -574,6 +574,9 @@ class Mock_Vehicle(MAVLink_Vehicle):
         self.mode = VehicleMode("GUIDED")
 
         return True
+
+    def pause(self):
+        self.mode = VehicleMode("PAUSE")
 
     def simple_takeoff(self, altitude):
         self.commands.takeoff(altitude)

--- a/vehicle/Robot_Vehicle_Arduino.py
+++ b/vehicle/Robot_Vehicle_Arduino.py
@@ -46,7 +46,7 @@ class Robot_Vehicle_Arduino(Robot_Vehicle):
 
     def activate(self):
         super(Robot_Vehicle_Arduino, self).activate()
-        
+
         # Send a DTR signal to turn on the Arduino via the RESET line. 
         # According to a forum post at 
         # http://forum.arduino.cc/index.php?topic=38981.msg287027#msg287027 and 
@@ -69,7 +69,15 @@ class Robot_Vehicle_Arduino(Robot_Vehicle):
 
     def deactivate(self):
         self._reset()
+
         super(Robot_Vehicle_Arduino, self).deactivate()
+
+    def pause(self):
+        super(Robot_Vehicle_Arduino, self).pause()
+
+        # If we are just halting, then only turn off the motors, not the 
+        # connection.
+        self.set_speeds(0, 0)
 
     def _format_speeds(self, left_speed, right_speed, left_forward, right_forward):
         output = ""

--- a/vehicle/Robot_Vehicle_Arduino_Full.py
+++ b/vehicle/Robot_Vehicle_Arduino_Full.py
@@ -22,6 +22,7 @@ class Robot_Vehicle_Arduino_Full(Robot_Vehicle_Arduino):
 
     def activate(self):
         super(Robot_Vehicle_Arduino_Full, self).activate()
+
         self._update_home_location()
         thread.start_new_thread(self._serial_loop, ())
 
@@ -29,6 +30,18 @@ class Robot_Vehicle_Arduino_Full(Robot_Vehicle_Arduino):
         # Send a DTR signal to turn off the Arduino. See the activate method.
         self._serial_connection.dtr = True
         self._serial_connection.close()
+
+    def pause(self):
+        super(Robot_Vehicle_Arduino_Full, self).pause()
+
+        self._serial_connection.write("\x03")
+        self._serial_connection.flush()
+
+    def unpause(self):
+        super(Robot_Vehicle_Arduino_Full, self).unpause()
+
+        self._serial_connection.write("CONT\n")
+        self._serial_connection.flush()
 
     def _update_home_location(self):
         # Format a "home location" command

--- a/vehicle/Vehicle.py
+++ b/vehicle/Vehicle.py
@@ -133,6 +133,20 @@ class Vehicle(Threadable):
 
         self._armed = value
 
+    def pause(self):
+        """
+        Stop the vehicle such that it attempts to remain in place.
+
+        The vehicle should stop any actions fairly quickly upon a pause.
+        Mission objectives such as moving to waypoints are frozen, i.e., they
+        are not actively sought after. The vehicle may be unpaused by changing
+        its vehicle mode to a new mode. The vehicle may automatically disarm
+        itself during its paused state, but this should not endanger itself or
+        make it impossible to continue later on.
+        """
+
+        raise NotImplementedError("Subclasses must implement `pause()`")
+
     def update_mission(self):
         """
         Propagate any updates to mission attributes, such as waypoints and

--- a/zigbee/RF_Sensor.py
+++ b/zigbee/RF_Sensor.py
@@ -186,8 +186,9 @@ class RF_Sensor(Threadable):
         Classes that inherit this base class may extend this method.
         """
 
-        self._started = True
+        self._scheduler.update()
         self._packets = []
+        self._started = True
 
     def stop(self):
         """
@@ -195,6 +196,10 @@ class RF_Sensor(Threadable):
         """
 
         self._started = False
+
+        # Reset the scheduler timestamp so that it updates correctly in case we 
+        # restart the sensor measurements.
+        self._scheduler.timestamp = 0
 
     def enqueue(self, packet, to=None):
         """

--- a/zigbee/RF_Sensor_Physical.py
+++ b/zigbee/RF_Sensor_Physical.py
@@ -110,8 +110,9 @@ class RF_Sensor_Physical(RF_Sensor):
         Classes that inherit this base class must extend this method.
         """
 
-        # Synchronize the scheduler using the timestamp in the packet.
-        self._scheduler.synchronize(packet)
+        if self._started:
+            # Synchronize the scheduler using the timestamp in the packet.
+            self._scheduler.synchronize(packet)
 
         # Create the packet for the ground station.
         return self._create_rssi_ground_station_packet(packet)

--- a/zigbee/RF_Sensor_Physical_Texas_Instruments.py
+++ b/zigbee/RF_Sensor_Physical_Texas_Instruments.py
@@ -92,7 +92,6 @@ class RF_Sensor_Physical_Texas_Instruments(RF_Sensor_Physical):
 
     def start(self):
         self._polling_time = time.time()
-        self._scheduler.update()
 
         super(RF_Sensor_Physical_Texas_Instruments, self).start()
 

--- a/zigbee/RF_Sensor_Simulator.py
+++ b/zigbee/RF_Sensor_Simulator.py
@@ -118,7 +118,8 @@ class RF_Sensor_Simulator(RF_Sensor):
         self._receive_callback(packet)
 
         if self._id > 0:
-            self._scheduler.synchronize(packet)
+            if self._started:
+                self._scheduler.synchronize(packet)
 
             # Create and complete the packet for the ground station.
             ground_station_packet = self._create_rssi_ground_station_packet(packet)

--- a/zigbee/TDMA_Scheduler.py
+++ b/zigbee/TDMA_Scheduler.py
@@ -43,6 +43,20 @@ class TDMA_Scheduler(object):
 
         return self._timestamp
 
+    @timestamp.setter
+    def timestamp(self, value):
+        """
+        Change the timestamp at which the sensor is allowed to send packets.
+
+        If this is set to `0`, then the sensor is allowed to send packets, and
+        the timestamp is corrected the next time the scheduler is updated.
+        This value can be of use when the measurements are paused for a longer
+        time, and we need to send at least one packet again to get back on
+        schedule after restarting.
+        """
+
+        self._timestamp = value
+
     def update(self):
         """
         Update the timestamp for sending packets.


### PR DESCRIPTION
Implement vehicle pausing, making it possible to halt a mission with the ability to continue it afterward using the IR remote control.

This almost immediately halts the vehicle, and all vehicle types are supported. It also stops the RF sensor RSSI sweeps, ensuring that the schedule is reset or repolled correctly afterward.

The vehicle and Arduino code was tested on the physical devices, and after some bug fixes for unexpectedly closed/reopened serial connections, it was deemed to work. The RF sensor stop/start was tested in the simulator runner.
