### PR TITLE
Waypoint types

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ go. The packages are sorted by purpose as follows:
     * matplotlib
     * NumPy
     * scipy
+    * enum34
 * Control panel:
     * PyQtGraph
     * markdown

--- a/control_panel/Control_Panel_Waypoints_View.py
+++ b/control_panel/Control_Panel_Waypoints_View.py
@@ -204,7 +204,7 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
                     data[i] = column["default"]
             else:
                 try:
-                    data[i] = self._cast_cell(i, data[i])
+                    data[i] = table.cast_cell(i, data[i])
                 except ValueError:
                     if errors:
                         raise ValueError("Invalid value for vehicle {}, row #{}, column '{}': '{}'".format(vehicle, row + 1, column["label"], data[i]))
@@ -212,22 +212,10 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
             if errors and "min" in column and data[i] < column["min"]:
                 raise ValueError("Invalid value for vehicle {}, row #{}, column '{}': {} must be at least {}".format(vehicle, row + 1, column["label"], data[i], column["min"]))
 
+        if errors and row > 0 and data[self._fields["type"]] == Waypoint_Type.HOME:
+            raise ValueError("Waypoint type for vehicle {}, row #{} may not be 'home'.".format(vehicle, row + 1))
+
         return data
-
-    def _cast_cell(self, col, text):
-        """
-        Change the text from a cell in column `col` to correct type.
-
-        Returns the casted value. Raises a `ValueError` if the text cannot be
-        casted to the appropriate value.
-        """
-
-        if self._columns[col]["default"] is not None:
-            type_cast = type(self._columns[col]["default"])
-        else:
-            type_cast = float
-
-        return type_cast(text)
 
     def _get_wait_id(self, vehicle, waypoint):
         """

--- a/control_panel/Control_Panel_Waypoints_View.py
+++ b/control_panel/Control_Panel_Waypoints_View.py
@@ -61,11 +61,13 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
                 "field": "wait_id",
                 "label": "wait for vehicle",
                 "default": 0,
+                "min": 0
             },
             {
                 "field": "wait_count",
                 "label": "wait count",
-                "default": 1
+                "default": 1,
+                "min": 1
             }
         ]
 
@@ -206,6 +208,9 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
                 except ValueError:
                     if errors:
                         raise ValueError("Invalid value for vehicle {}, row #{}, column '{}': '{}'".format(vehicle, row + 1, column["label"], data[i]))
+
+            if errors and "min" in column and data[i] < column["min"]:
+                raise ValueError("Invalid value for vehicle {}, row #{}, column '{}': {} must be at least {}".format(vehicle, row + 1, column["label"], data[i], column["min"]))
 
         return data
 

--- a/control_panel/Control_Panel_Waypoints_View.py
+++ b/control_panel/Control_Panel_Waypoints_View.py
@@ -35,6 +35,8 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
         # - "widget": A cell widget type to fill in the rows. The given type
         #   must be a subclass of `QtWidget`, and it must implement two 
         #   methods: `get_value` and `set_value(data)`.
+        # - "min": The minimum numeric value for the cell. The cell is
+        #   considered invalid if it is lower than this value.
         self._columns = [
             {
                 "field": "north",

--- a/control_panel/Control_Panel_Waypoints_View.py
+++ b/control_panel/Control_Panel_Waypoints_View.py
@@ -645,6 +645,7 @@ class Control_Panel_Waypoints_View(Control_Panel_View):
         packet.set("latitude", waypoint[self._fields["north"]])
         packet.set("longitude", waypoint[self._fields["east"]])
         packet.set("altitude", waypoint[self._fields["alt"]])
+        packet.set("type", int(waypoint[self._fields["type"]]))
         packet.set("wait_id", int(waypoint[self._fields["wait_id"]]))
         packet.set("wait_count", int(waypoint[self._fields["wait_count"]]))
         packet.set("index", index)

--- a/control_panel/Control_Panel_Waypoints_Widgets.py
+++ b/control_panel/Control_Panel_Waypoints_Widgets.py
@@ -20,6 +20,16 @@ class WaypointTypeWidget(QtGui.QComboBox):
         self.setCurrentIndex(default - 1)
 
     def _update_row_type(self, index):
+        """
+        Update the other cells in the row of this cell widget based on the
+        waypoint type.
+
+        The `index` is the index associated with the selected combo box item,
+        starting from `0`. The two cells next to this cell widget, which are
+        in the "wait ID" and "wait count" columns, are enabled or disabled
+        based on whether the `index` belongs to the wait type waypoint.
+        """
+
         if index + 1 != Waypoint_Type.WAIT:
             flagger = lambda f: f & ~QtCore.Qt.ItemIsEditable & ~QtCore.Qt.ItemIsSelectable & ~QtCore.Qt.ItemIsEnabled
             color = QtGui.QColor("#e8e8e8")
@@ -35,9 +45,25 @@ class WaypointTypeWidget(QtGui.QComboBox):
             item.setBackground(color)
 
     def get_value(self):
+        """
+        Retrieve the current waypoint type value.
+
+        The value is returned as an integer corresponding to the `Waypoint_Type`
+        enumeration.
+        """
+
         return self.currentIndex() + 1
 
     def set_value(self, index):
+        """
+        Alter the current waypoint type.
+
+        The given `index` is a `Waypoint_Type` or comparable integer. The combo
+        box is updated to select the appropriate type, and other cells in this
+        row are enabled or disabled based on whether the `index` belongs to the
+        wait type waypoint.
+        """
+
         self.setCurrentIndex(index - 1)
 
 class WaypointsTableWidget(QtGui.QTableWidget):
@@ -218,6 +244,9 @@ class WaypointsTableWidget(QtGui.QTableWidget):
 
         endRow = self.rowCount() - 1
         endCol = self.columnCount() - 1
+
+        # Try any selectable item in the remainder of the row, or the next or 
+        # previous row's start/end, or the first/last cell of the table.
         if next:
             options = [(row, j) for j in range(col+1, endCol+1)]
             options.extend([(row+1, 0), (0, 0)])
@@ -229,6 +258,8 @@ class WaypointsTableWidget(QtGui.QTableWidget):
         for newRow, newCol in options:
             index = currentIndex.sibling(newRow, newCol)
             if index.isValid():
+                # Skip cells that have a default of `0`, because those cells 
+                # are more "optional" than any of the others.
                 if self._columns[newCol]["default"] == 0:
                     continue
 
@@ -251,6 +282,8 @@ class WaypointsTableWidget(QtGui.QTableWidget):
         if self.tabKeyNavigation():
             index = self._get_tab_index(next)
             if index.isValid():
+                # Focus on the item and enable the editor so that we can easily 
+                # alter the waypoints using only the keyboard.
                 self.setCurrentIndex(index)
                 self.editItem(self.itemFromIndex(index))
                 return True

--- a/control_panel/Control_Panel_Waypoints_Widgets.py
+++ b/control_panel/Control_Panel_Waypoints_Widgets.py
@@ -70,6 +70,46 @@ class WaypointsTableWidget(QtGui.QTableWidget):
         verticalHeader.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         verticalHeader.customContextMenuRequested.connect(self._make_menu)
 
+        self.itemChanged.connect(self._item_changed)
+
+    def _item_changed(self, item):
+        """
+        Checks whether the given `item`, a `QTableWidgetItem`, is still valid.
+        """
+
+        col = self.column(item)
+        text = item.text()
+        valid = True
+
+        if text != "":
+            try:
+                value = self.cast_cell(col, item.text())
+            except ValueError:
+                valid = False
+
+            if valid and "min" in self._columns[col]:
+                valid = value >= self._columns[col]["min"]
+
+        if not valid:
+            item.setBackground(QtGui.QColor("#FA6969"))
+        elif item.flags() & QtCore.Qt.ItemIsEnabled:
+            item.setBackground(QtGui.QBrush())
+
+    def cast_cell(self, col, text):
+        """
+        Change the value `text` from a cell in column `col` to correct type.
+
+        Returns the casted value. Raises a `ValueError` if the text cannot be
+        casted to the appropriate value.
+        """
+
+        if self._columns[col]["default"] is not None:
+            type_cast = type(self._columns[col]["default"])
+        else:
+            type_cast = float
+
+        return type_cast(text)
+
     def get_row_data(self, row):
         """
         Retrieve the cell data from the given row number `row`.

--- a/control_panel/Control_Panel_Waypoints_Widgets.py
+++ b/control_panel/Control_Panel_Waypoints_Widgets.py
@@ -1,23 +1,68 @@
 from functools import partial
 from PyQt4 import QtCore, QtGui
+from ..waypoint.Waypoint import Waypoint_Type
+
+class WaypointTypeWidget(QtGui.QComboBox):
+    """
+    A table cell widget that makes it possible to select a certain waypoint type
+    for the waypoint data associated with that row.
+    """
+
+    def __init__(self, table, row, col, default, *a, **kw):
+        super(WaypointTypeWidget, self).__init__(*a, **kw)
+
+        self._table = table
+        self._row = row
+        self._col = col
+
+        self.addItems([item.name.lower() for item in iter(Waypoint_Type)])
+
+        self.currentIndexChanged[int].connect(self._update_row_type)
+        self.setCurrentIndex(default - 1)
+
+    def _update_row_type(self, index):
+        if index + 1 != Waypoint_Type.WAIT:
+            flagger = lambda f: f & ~QtCore.Qt.ItemIsEditable & ~QtCore.Qt.ItemIsSelectable & ~QtCore.Qt.ItemIsEnabled
+            color = QtGui.QColor("#e8e8e8")
+        else:
+            flagger = lambda f: f | QtCore.Qt.ItemIsEditable | QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled
+            color = QtGui.QBrush()
+
+        for i in range(1, 3):
+            item = self._table.item(self._row, self._col + i)
+            if item is None:
+                item = QtGui.QTableWidgetItem()
+                self._table.setItem(self._row, self._col + i, item)
+
+            item.setFlags(flagger(item.flags()))
+            item.setBackground(color)
+
+    def get_value(self):
+        return self.currentIndex() + 1
+
+    def set_value(self, index):
+        self.setCurrentIndex(index - 1)
 
 class WaypointsTableWidget(QtGui.QTableWidget):
-    def __init__(self, column_labels, column_defaults, *a, **kw):
+    """
+    A table widget with specialized rows for supplying waypoint data.
+    """
+
+    def __init__(self, columns, *a, **kw):
         super(WaypointsTableWidget, self).__init__(*a, **kw)
 
-        # We assume that `len(column_labels) == len(column_defaults)`, and that 
-        # the defaults are `None` for columns without defaults and something 
-        # else for columns with defaults. The column without defaults must be 
-        # the first columns in the table, otherwise the tab ordering does not 
-        # match the characteristics of the columns.
-        self._column_defaults = column_defaults
+        # We assume that the defaults are `None` for columns without defaults 
+        # and something else for columns with defaults. The column without 
+        # defaults must be the first columns in the table, otherwise the tab 
+        # ordering does not match the characteristics of the columns.
+        self._columns = columns
 
-        self.setRowCount(1)
-        self.setColumnCount(len(column_labels))
-        self.setHorizontalHeaderLabels(column_labels)
+        self.setColumnCount(len(columns))
+        self.setHorizontalHeaderLabels([column["label"] for column in columns])
+        self.insertRow(0)
 
         horizontalHeader = self.horizontalHeader()
-        for i in range(len(column_labels)):
+        for i in range(len(columns)):
             horizontalHeader.setResizeMode(i, QtGui.QHeaderView.Stretch)
 
         # Create the context menu for the rows in the table.
@@ -39,11 +84,18 @@ class WaypointsTableWidget(QtGui.QTableWidget):
 
         empty = True
         data = []
-        for col in range(len(self._column_defaults)):
+        for col, column in enumerate(self._columns):
+            if "widget" in column:
+                widget = self.cellWidget(row, col)
+                data.append(widget.get_value())
+                continue
+
             item = self.item(row, col)
-            # Handle unaltered column cells (no item widget) and empty columns 
-            # (text contents equals to empty string)
+            # Handle unaltered column cells (no item widget), empty columns 
+            # (text contents equals to empty string) and disabled cells.
             if item is None or item.text() == "":
+                data.append(None)
+            elif not (item.flags() & QtCore.Qt.ItemIsEnabled):
                 data.append(None)
             else:
                 data.append(item.text())
@@ -51,20 +103,54 @@ class WaypointsTableWidget(QtGui.QTableWidget):
 
         return data, empty
 
+    def insert_data_row(self, row, data):
+        """
+        Set the cell data for the given `row` from a list `data`.
+
+        The given `row` must be a row index number where the row should be
+        inserted at. If the `data` is not long enough, i.e., it does not provide
+        a value for required columns, then a `ValueError` is raised.
+        """
+
+        self.insertRow(row)
+
+        for col, column in enumerate(self._columns):
+            if col >= len(data):
+                if column["default"] is None:
+                    # Data is required for this column, but it is not provided.
+                    raise ValueError("Row #{} has missing information for column '{}'".format(row + 1, column["label"]))
+
+                break
+
+            if "widget" in column:
+                widget = self.cellWidget(row, col)
+                widget.set_value(data[col])
+            elif data[col] != column["default"]:
+                item = str(data[col])
+                self.setItem(row, col, QtGui.QTableWidgetItem(item))
+
+    def insertRow(self, row):
+        super(WaypointsTableWidget, self).insertRow(row)
+
+        for col, column in enumerate(self._columns):
+            if "widget" in column:
+                widget = column["widget"](self, row, col, column["default"])
+                self.setCellWidget(row, col, widget)
+
     def removeRows(self):
         """
         Remove all the rows in the table.
         """
 
-        for row in reversed(range(self.rowCount())):
-            self.removeRow(row)
+        self.setRowCount(0)
 
     def _get_tab_index(self, next):
         """
         Determine the `QModelIndex` belonging to the next or previous item.
 
-        The waypoints table has a special tab order that follows the columns
-        without defaults first, and only then goes to columns with defaults.
+        The waypoints table has a special tab order that skips the columns
+        with defaults that are equal to `0`, i.e., not `None` or some other
+        nonzero value. It also skips cells that cannot be selected.
 
         If `next` is `True`, then we want to receive an index for the first
         logical item after the current item, otherwise we want the index for
@@ -78,31 +164,23 @@ class WaypointsTableWidget(QtGui.QTableWidget):
 
         endRow = self.rowCount() - 1
         endCol = self.columnCount() - 1
-        if self._column_defaults[col] is not None:
-            # Navigate down/up in columns with defaults, and otherwise jump to 
-            # the beginning/end of the next row or the table start/end
-            if next:
-                options = [(row+1, col), (0, col+1), (0, 0)]
-            else:
-                options = [(row-1, col), (endRow, col-1), (endRow, endCol)]
+        if next:
+            options = [(row, j) for j in range(col+1, endCol+1)]
+            options.extend([(row+1, 0), (0, 0)])
         else:
-            # Navigate right/left in columns without defaults, but skip columns 
-            # with defaults, by going to the first/last column without defaults 
-            # of the next/previous row if one would go to such column with 
-            # defaults. If no such row exists anymore, go to the first/last 
-            # column with defaults on the first/last row.
-            lastCol = max(enumerate(self._column_defaults), key=lambda x: x[0] if x[1] is None else 0)[0]
-            if next:
-                options = [(row+1, 0), (0, col+1), (0, 0)]
-                if col != lastCol:
-                    options[0:0] = [(row, col+1)]
-            else:
-                options = [(row, col-1), (row-1, lastCol), (endRow, endCol)]
+            options = [(row, j) for j in range(col-1, -1, -1)]
+            options.extend([(row-1, j) for j in range(endCol, -1, -1)])
+            options.append((endRow, endCol))
 
         for newRow, newCol in options:
             index = currentIndex.sibling(newRow, newCol)
             if index.isValid():
-                return index
+                if self._columns[newCol]["default"] == 0:
+                    continue
+
+                item = self.itemFromIndex(index)
+                if item is None or item.flags() & QtCore.Qt.ItemIsSelectable:
+                    return index
 
         # Return an invalid model index if no valid next index is found.
         return QtCore.QModelIndex()
@@ -120,6 +198,7 @@ class WaypointsTableWidget(QtGui.QTableWidget):
             index = self._get_tab_index(next)
             if index.isValid():
                 self.setCurrentIndex(index)
+                self.editItem(self.itemFromIndex(index))
                 return True
 
             return False

--- a/mission/Mission_Auto.py
+++ b/mission/Mission_Auto.py
@@ -66,19 +66,20 @@ class Mission_Auto(Mission):
         alt = point.alt if point.alt != 0.0 else self.altitude
         return self.geometry.make_location(point.lat, point.lon, alt)
 
-    def add_waypoint(self, point, required_sensors=None):
+    def add_waypoint(self, point, wait=True, required_sensors=None):
         """
         Add a waypoint location object `point` to the vehicle's mission command
         waypoints.
 
-        If RF sensor synchronization is enabled, also adds a wait command afterward.
-        The option `required_sensors` list determines which sensors ID to wait
-        for in the measurement validation.
+        If RF sensor synchronization is enabled and `wait` is `True`, then this
+        also adds a wait command afterward. `required_sensors` is a list which
+        determines which sensors ID to wait for in the measurement validation.
+        If it is not given, then we assume we have to wait for all sensors.
         """
 
         self.vehicle.add_waypoint(self._convert_waypoint(point))
 
-        if self._rf_sensor_synchronization:
+        if self._rf_sensor_synchronization and wait:
             self.vehicle.add_wait()
             self._required_waypoint_sensors.append(required_sensors)
 

--- a/mission/Mission_RF_Sensor.py
+++ b/mission/Mission_RF_Sensor.py
@@ -147,6 +147,8 @@ class Mission_RF_Sensor(Mission_Auto):
             self.add_waypoint(point, wait=wait,
                               required_sensors=required_sensors)
 
+        waypoint.update_vehicle(self.vehicle)
+
         self._next_index += 1
         self._point = location
         self._send_ack()

--- a/mission/Mission_RF_Sensor.py
+++ b/mission/Mission_RF_Sensor.py
@@ -133,9 +133,19 @@ class Mission_RF_Sensor(Mission_Auto):
                                    previous_location=self._point,
                                    wait_id=wait_id, wait_count=wait_count)
 
-        required_sensors = waypoint.get_required_sensors()
+        # Retrieve the required sensors. A return value `None` actually means 
+        # we want to wait for all other sensors, while an exception means we do 
+        # not support waiting for this waypoint.
+        try:
+            wait = True
+            required_sensors = waypoint.get_required_sensors()
+        except RuntimeError:
+            wait = False
+            required_sensors = None
+
         for point in waypoint.get_points():
-            self.add_waypoint(point, required_sensors)
+            self.add_waypoint(point, wait=wait,
+                              required_sensors=required_sensors)
 
         self._next_index += 1
         self._point = location

--- a/mission/Mission_RF_Sensor.py
+++ b/mission/Mission_RF_Sensor.py
@@ -37,6 +37,12 @@ class Mission_RF_Sensor(Mission_Auto):
 
         self._waypoints_complete = True
 
+        # Send an acknowledgement to the ground station so that it knows that 
+        # we have received a "done" packet. Increment the next index to signify 
+        # this acknowledgement as totally done.
+        self._next_index += 1
+        self._send_ack()
+
     @property
     def waypoints_complete(self):
         """

--- a/planning/Greedy_Assignment.py
+++ b/planning/Greedy_Assignment.py
@@ -1,5 +1,6 @@
 import itertools
 import numpy as np
+from ..waypoint.Waypoint import Waypoint_Type
 
 class Greedy_Assignment(object):
     """
@@ -54,9 +55,12 @@ class Greedy_Assignment(object):
             # The coordinates of the next position for the given vehicle.
             new_position = list(positions[closest_pair, i, :])
 
-            # Create an assignment containing the full position and the other 
+            # The assigned waypoint containing the full position and the other 
             # vehicle's wait ID.
-            assignment[vehicle].append(new_position + [0, other_vehicle])
+            waypoint = new_position + [0, Waypoint_Type.WAIT, other_vehicle, 1]
+
+            # Create the assignment and track the new position.
+            assignment[vehicle].append(waypoint)
             current_positions[vehicle-1] = new_position
 
     def assign(self, positions_pairs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 matplotlib
 NumPy
 scipy
+enum34
 
 # Control panel
 PyQtGraph

--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -645,7 +645,7 @@
                 "help": "Whether to use discrete grid cells instead of allowing measurements to happen anywhere",
                 "short": "Discrete",
                 "type": "bool",
-                "default": false
+                "default": true
             }
         }
     },
@@ -741,7 +741,7 @@
                     "length": 2,
                     "subtype": "int"
                 },
-                "default": [[0, 0], [0, 9]]
+                "default": [[0, 0], [0, 19]]
             }
         }
     },

--- a/tests/mission_rf_sensor.py
+++ b/tests/mission_rf_sensor.py
@@ -1,7 +1,9 @@
 from mock import patch
 from dronekit import LocationLocal
+from ..environment.Environment import Environment
 from ..mission.Mission_RF_Sensor import Mission_RF_Sensor
 from ..vehicle.Robot_Vehicle import Robot_State
+from ..waypoint.Waypoint import Waypoint_Type
 from ..zigbee.Packet import Packet
 from ..zigbee.RF_Sensor import RF_Sensor
 from environment import EnvironmentTestCase
@@ -43,6 +45,14 @@ class TestMissionRFSensor(EnvironmentTestCase):
         self.assertFalse(self.mission.waypoints_complete)
         self.assertEqual(self.mission.next_index, 0)
 
+    @patch.object(Environment, "get_rf_sensor", return_value=None)
+    def test_setup_no_rf_sensor(self, get_rf_sensor_mock):
+        with self.assertRaises(ValueError):
+            with patch('sys.stdout'):
+                self.mission.setup()
+
+        get_rf_sensor_mock.assert_called_once_with()
+
     def test_get_points(self):
         # An RF sensor mission has no predetermined AUTO points.
         self.assertEqual(self.mission.get_points(), [])
@@ -68,6 +78,7 @@ class TestMissionRFSensor(EnvironmentTestCase):
         packet.set("latitude", latitude)
         packet.set("longitude", longitude)
         packet.set("altitude", altitude)
+        packet.set("type", int(Waypoint_Type.WAIT))
         packet.set("wait_id", wait_id)
         packet.set("wait_count", wait_count)
         packet.set("to_id", self.rf_sensor.id + id_offset)

--- a/tests/mission_rf_sensor.py
+++ b/tests/mission_rf_sensor.py
@@ -157,7 +157,20 @@ class TestMissionRFSensor(EnvironmentTestCase):
         self.assertEqual(kwargs, {"to": 0})
 
         self.assertEqual(self.mission.next_index, 1)
+        self.assertEqual(self.mission._point, LocationLocal(1.0, 4.0, 0.0))
         self.assertEqual(self.vehicle._waypoints, [(1, 4), None])
+
+    def test_add_waypoint_home(self):
+        with patch('sys.stdout'):
+            self.mission.setup()
+
+        home_location = LocationLocal(5.0, 15.0, 0.0)
+        self.enqueue_mock.reset_mock()
+        self._send_waypoint_add(0, 5.0, 15.0, type=Waypoint_Type.HOME)
+        self.assertEqual(self.mission.next_index, 1)
+        self.assertEqual(self.vehicle.home_location, home_location)
+        self.assertEqual(self.mission._point, home_location)
+        self.assertEqual(self.vehicle._waypoints, [])
 
     def test_add_waypoint_wait_count(self):
         with patch('sys.stdout'):

--- a/tests/mission_rf_sensor.py
+++ b/tests/mission_rf_sensor.py
@@ -231,9 +231,20 @@ class TestMissionRFSensor(EnvironmentTestCase):
         self.enqueue_mock.reset_mock()
         self._send_packet("waypoint_done")
 
-        # We do not send an acknowledgment (and request for next ID) when the 
-        # waypoints are done.
-        self.assertEqual(self.enqueue_mock.call_count, 0)
+        # We send an acknowledgment (with another ID) when the waypoints are 
+        # done.
+        self.assertEqual(self.enqueue_mock.call_count, 1)
+        args, kwargs = self.enqueue_mock.call_args
+        self.assertEqual(len(args), 1)
+        self.assertIsInstance(args[0], Packet)
+        self.assertEqual(args[0].get_all(), {
+            "specification": "waypoint_ack",
+            "next_index": 5,
+            "sensor_id": self.rf_sensor.id
+        })
+        self.assertEqual(kwargs, {"to": 0})
+
+        self.assertEqual(self.mission.next_index, 5)
 
         self.assertTrue(self.mission.waypoints_complete)
         self.assertEqual(self.vehicle._waypoints, [

--- a/tests/planning_greedy_assignment.py
+++ b/tests/planning_greedy_assignment.py
@@ -2,6 +2,7 @@ import numpy as np
 from ..geometry.Geometry_Grid import Geometry_Grid
 from ..planning.Greedy_Assignment import Greedy_Assignment
 from ..settings import Arguments
+from ..waypoint.Waypoint import Waypoint_Type
 from settings import SettingsTestCase
 
 class TestPlanningGreedyAssignment(SettingsTestCase):
@@ -13,14 +14,14 @@ class TestPlanningGreedyAssignment(SettingsTestCase):
     def test_init(self):
         self.assertEqual(self.assigner._geometry, self.geometry)
         self.assertEqual(self.assigner._number_of_vehicles, 2)
-        self.assertEqual(self.assigner._home_locations, [[0, 0], [0, 9]])
+        self.assertEqual(self.assigner._home_locations, [[0, 0], [0, 19]])
         self.assertEqual(self.assigner._vehicle_pairs, [(1, 2), (2, 1)])
 
     def test_assign(self):
-        positions = np.array([[[3, 0], [5, 6]],
-                              [[2, 9], [0, 1]],
-                              [[0, 0], [1, 6]],
-                              [[4, 8], [9, 1]]])
+        positions = np.array([[[3, 0], [5, 16]],
+                              [[2, 19], [0, 1]],
+                              [[0, 0], [1, 16]],
+                              [[4, 18], [19, 1]]])
 
         assignment = self.assigner.assign(positions)[0]
 
@@ -28,7 +29,14 @@ class TestPlanningGreedyAssignment(SettingsTestCase):
         self.assertEqual(positions.shape, (4, 2, 2))
 
         # We receive a good assignment.
-        self.assertEqual(assignment, {
-            1: [[0, 0, 0, 2], [0, 1, 0, 2], [3, 0, 0, 2], [9, 1, 0, 2]],
-            2: [[1, 6, 0, 1], [2, 9, 0, 1], [5, 6, 0, 1], [4, 8, 0, 1]]
-        })
+        wait = Waypoint_Type.WAIT
+        self.assertIsInstance(assignment, dict)
+        self.assertEqual(len(assignment), 2)
+        self.assertEqual(assignment[1], [
+            [0, 0, 0, wait, 2, 1], [0, 1, 0, wait, 2, 1],
+            [3, 0, 0, wait, 2, 1], [19, 1, 0, wait, 2, 1]
+        ])
+        self.assertEqual(assignment[2], [
+            [1, 16, 0, wait, 1, 1], [2, 19, 0, wait, 1, 1],
+            [5, 16, 0, wait, 1, 1], [4, 18, 0, wait, 1, 1]
+        ])

--- a/tests/waypoint.py
+++ b/tests/waypoint.py
@@ -1,15 +1,39 @@
-import unittest
-from ..waypoint.Waypoint import Waypoint
+from dronekit import LocationLocal
+from mock import patch
+from ..core.Import_Manager import Import_Manager
+from ..waypoint.Waypoint import Waypoint, Waypoint_Type
+from geometry import LocationTestCase
 
-class TestWaypoint(unittest.TestCase):
+class TestWaypoint(LocationTestCase):
     def setUp(self):
-        self.waypoint = Waypoint(1)
+        super(TestWaypoint, self).setUp()
+
+        self.waypoint = Waypoint(1, LocationLocal(2.0, 3.0, -4.0))
+
+    @patch.object(Import_Manager, "load_class")
+    def test_create(self, load_class_mock):
+        import_manager = Import_Manager()
+        waypoint = Waypoint.create(import_manager, Waypoint_Type.WAIT, 42,
+                                   LocationLocal(5.0, 6.0, -7.0),
+                                   wait_id=2, wait_count=9)
+
+        load_class_mock.assert_called_once_with("Waypoint_Wait",
+                                                relative_module="waypoint")
+
+        # The object is created with the appropriate arguments.
+        self.assertEqual(waypoint, load_class_mock.return_value.return_value)
+        self.assertEqual(load_class_mock.return_value.call_count, 1)
+        args, kwargs = load_class_mock.return_value.call_args
+        self.assertEqual(args[0], 42)
+        self.assertEqual(args[1], LocationLocal(5.0, 6.0, -7.0))
+        self.assertEqual(kwargs, {"wait_id": 2, "wait_count": 9})
 
     def test_interface(self):
         with self.assertRaises(NotImplementedError):
             dummy = self.waypoint.name
 
         self.assertEqual(self.waypoint.vehicle_id, 1)
+        self.assertEqual(self.waypoint.location, LocationLocal(2.0, 3.0, -4.0))
 
     def test_get_points(self):
         with self.assertRaises(NotImplementedError):

--- a/tests/waypoint.py
+++ b/tests/waypoint.py
@@ -1,7 +1,8 @@
 from dronekit import LocationLocal
-from mock import patch
+from mock import patch, MagicMock
 from ..core.Import_Manager import Import_Manager
 from ..geometry.Geometry import Geometry
+from ..vehicle.Vehicle import Vehicle
 from ..waypoint.Waypoint import Waypoint, Waypoint_Type
 from geometry import LocationTestCase
 
@@ -47,3 +48,10 @@ class TestWaypoint(LocationTestCase):
     def test_get_required_sensors(self):
         with self.assertRaises(RuntimeError):
             self.waypoint.get_required_sensors()
+
+    def test_update_vehicle(self):
+        # The `vehicle` parameter must be a vehicle.
+        with self.assertRaises(TypeError):
+            self.waypoint.update_vehicle(self.geometry)
+
+        self.waypoint.update_vehicle(MagicMock(spec_set=Vehicle))

--- a/tests/waypoint.py
+++ b/tests/waypoint.py
@@ -1,0 +1,16 @@
+import unittest
+from ..waypoint.Waypoint import Waypoint
+
+class TestWaypoint(unittest.TestCase):
+    def setUp(self):
+        self.waypoint = Waypoint(1)
+
+    def test_interface(self):
+        with self.assertRaises(NotImplementedError):
+            dummy = self.waypoint.name
+
+        self.assertEqual(self.waypoint.vehicle_id, 1)
+
+    def test_get_points(self):
+        with self.assertRaises(NotImplementedError):
+            self.waypoint.get_points()

--- a/tests/waypoint.py
+++ b/tests/waypoint.py
@@ -1,6 +1,7 @@
 from dronekit import LocationLocal
 from mock import patch
 from ..core.Import_Manager import Import_Manager
+from ..geometry.Geometry import Geometry
 from ..waypoint.Waypoint import Waypoint, Waypoint_Type
 from geometry import LocationTestCase
 
@@ -8,13 +9,16 @@ class TestWaypoint(LocationTestCase):
     def setUp(self):
         super(TestWaypoint, self).setUp()
 
-        self.waypoint = Waypoint(1, LocationLocal(2.0, 3.0, -4.0))
+        self.geometry = Geometry()
+        self.location = LocationLocal(2.0, 3.0, -4.0)
+        self.waypoint = Waypoint(1, self.geometry, self.location)
 
     @patch.object(Import_Manager, "load_class")
     def test_create(self, load_class_mock):
         import_manager = Import_Manager()
+        geometry = Geometry()
         waypoint = Waypoint.create(import_manager, Waypoint_Type.WAIT, 42,
-                                   LocationLocal(5.0, 6.0, -7.0),
+                                   geometry, LocationLocal(5.0, 6.0, -7.0),
                                    wait_id=2, wait_count=9)
 
         load_class_mock.assert_called_once_with("Waypoint_Wait",
@@ -25,7 +29,8 @@ class TestWaypoint(LocationTestCase):
         self.assertEqual(load_class_mock.return_value.call_count, 1)
         args, kwargs = load_class_mock.return_value.call_args
         self.assertEqual(args[0], 42)
-        self.assertEqual(args[1], LocationLocal(5.0, 6.0, -7.0))
+        self.assertEqual(args[1], geometry)
+        self.assertEqual(args[2], LocationLocal(5.0, 6.0, -7.0))
         self.assertEqual(kwargs, {"wait_id": 2, "wait_count": 9})
 
     def test_interface(self):
@@ -33,8 +38,12 @@ class TestWaypoint(LocationTestCase):
             dummy = self.waypoint.name
 
         self.assertEqual(self.waypoint.vehicle_id, 1)
-        self.assertEqual(self.waypoint.location, LocationLocal(2.0, 3.0, -4.0))
+        self.assertEqual(self.waypoint.location, self.location)
 
     def test_get_points(self):
         with self.assertRaises(NotImplementedError):
             self.waypoint.get_points()
+
+    def test_get_required_sensors(self):
+        with self.assertRaises(RuntimeError):
+            self.waypoint.get_required_sensors()

--- a/tests/waypoint_home.py
+++ b/tests/waypoint_home.py
@@ -1,0 +1,30 @@
+from dronekit import LocationLocal
+from mock import MagicMock
+from ..geometry.Geometry import Geometry
+from ..vehicle.Vehicle import Vehicle
+from ..waypoint.Waypoint import Waypoint_Type
+from ..waypoint.Waypoint_Home import Waypoint_Home
+from geometry import LocationTestCase
+
+class TestWaypointHome(LocationTestCase):
+    def setUp(self):
+        super(TestWaypointHome, self).setUp()
+
+        self.geometry = Geometry()
+        self.location = LocationLocal(1.2, 3.4, -5.6)
+        self.waypoint = Waypoint_Home(1, self.geometry, self.location)
+
+    def test_name(self):
+        self.assertEqual(self.waypoint.name, Waypoint_Type.HOME)
+
+    def test_get_points(self):
+        self.assertEqual(self.waypoint.get_points(), [])
+
+    def test_update_vehicle(self):
+        # The `vehicle` parameter must be a vehicle.
+        with self.assertRaises(TypeError):
+            self.waypoint.update_vehicle(self.geometry)
+
+        vehicle_mock = MagicMock(spec_set=Vehicle)
+        self.waypoint.update_vehicle(vehicle_mock)
+        self.assertEqual(vehicle_mock.home_location, self.location)

--- a/tests/waypoint_pass.py
+++ b/tests/waypoint_pass.py
@@ -1,0 +1,21 @@
+from dronekit import LocationLocal
+from ..geometry.Geometry import Geometry
+from ..waypoint.Waypoint import Waypoint_Type
+from ..waypoint.Waypoint_Pass import Waypoint_Pass
+from geometry import LocationTestCase
+
+class TestWaypointPass(LocationTestCase):
+    def setUp(self):
+        super(TestWaypointPass, self).setUp()
+
+        self.geometry = Geometry()
+        self.location = LocationLocal(1.2, 3.4, -5.6)
+        self.waypoint = Waypoint_Pass(1, self.geometry, self.location)
+
+    def test_name(self):
+        self.assertEqual(self.waypoint.name, Waypoint_Type.PASS)
+
+    def test_get_points(self):
+        points = self.waypoint.get_points()
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0], self.location)

--- a/tests/waypoint_wait.py
+++ b/tests/waypoint_wait.py
@@ -1,0 +1,41 @@
+from dronekit import LocationLocal
+from ..geometry.Geometry import Geometry
+from ..waypoint.Waypoint import Waypoint_Type
+from ..waypoint.Waypoint_Wait import Waypoint_Wait
+from geometry import LocationTestCase
+
+class TestWaypointWait(LocationTestCase):
+    def setUp(self):
+        super(TestWaypointWait, self).setUp()
+
+        self.geometry = Geometry()
+        self.location = LocationLocal(0.0, 10.0, 0.0)
+        self.waypoint = Waypoint_Wait(1, self.geometry, self.location,
+                                      wait_id=2, wait_count=5)
+
+    def test_name(self):
+        self.assertEqual(self.waypoint.name, Waypoint_Type.WAIT)
+
+    def test_get_points(self):
+        points = self.waypoint.get_points()
+        self.assertEqual(len(points), 5)
+        self.assertEqual(points[0], LocationLocal(0.0, 2.0, 0.0))
+        self.assertEqual(points[1], LocationLocal(0.0, 4.0, 0.0))
+        self.assertEqual(points[2], LocationLocal(0.0, 6.0, 0.0))
+        self.assertEqual(points[3], LocationLocal(0.0, 8.0, 0.0))
+        self.assertEqual(points[4], LocationLocal(0.0, 10.0, 0.0))
+
+    def test_get_required_sensors(self):
+        self.assertEqual(self.waypoint.get_required_sensors(), [2])
+
+    def test_initialization_previous_waypoint(self):
+        waypoint = Waypoint_Wait(1, self.geometry, self.location,
+                                 previous_location=LocationLocal(10, 10, 0),
+                                 wait_id=0, wait_count=2)
+
+        points = waypoint.get_points()
+        self.assertEqual(len(points), 2)
+        self.assertEqual(points[0], LocationLocal(5.0, 10.0, 0.0))
+        self.assertEqual(points[1], LocationLocal(0.0, 10.0, 0.0))
+
+        self.assertIsNone(waypoint.get_required_sensors())

--- a/tests/zigbee_packet.py
+++ b/tests/zigbee_packet.py
@@ -18,12 +18,13 @@ class ZigBeePacketTestCase(unittest.TestCase):
         self.waypoint_add_packet.set("latitude", 123456789.12)
         self.waypoint_add_packet.set("longitude", 123496785.34)
         self.waypoint_add_packet.set("altitude", 4.2)
+        self.waypoint_add_packet.set("type", 1)
         self.waypoint_add_packet.set("wait_id", 3)
         self.waypoint_add_packet.set("wait_count", 6)
         self.waypoint_add_packet.set("index", 22)
         self.waypoint_add_packet.set("to_id", 2)
         self.waypoint_add_message = "\x06H\xe1zT4o\x9dA\xf6(\\E\xa5q\x9dA" + \
-                                    "\xcd\xcc\xcc\xcc\xcc\xcc\x10@\x03" + \
+                                    "\xcd\xcc\xcc\xcc\xcc\xcc\x10@\x01\x03" + \
                                     "\x06\x00\x00\x00\x16\x00\x00\x00\x02"
         self.setting_add_message = "\n\x00\x00\x00\x00\x03bar\x01i" + \
                                    "*\x00\x00\x00\x01"
@@ -205,6 +206,7 @@ class TestZigBeePacket(ZigBeePacketTestCase):
             "latitude": 123456789.12,
             "longitude": 123496785.34,
             "altitude": 4.2,
+            "type": 1,
             "wait_id": 3,
             "wait_count": 6,
             "index": 22,

--- a/waypoint/Waypoint.py
+++ b/waypoint/Waypoint.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from ..vehicle.Vehicle import Vehicle
 
 class Waypoint_Type(IntEnum):
     HOME = 1
@@ -91,3 +92,15 @@ class Waypoint(object):
         """
 
         raise RuntimeError("Waypoint does not support waiting for required sensors")
+
+    def update_vehicle(self, vehicle):
+        """
+        Update the state of the given `vehicle`, a `Vehicle` object.
+
+        The waypoint need not add itself to the vehicle's waypoint commands;
+        we assume that this has already done. If any additional state changes
+        are necessary, then we can do them here.
+        """
+
+        if not isinstance(vehicle, Vehicle):
+            raise TypeError("`vehicle` must be a `Vehicle` object")

--- a/waypoint/Waypoint.py
+++ b/waypoint/Waypoint.py
@@ -11,13 +11,37 @@ class Waypoint(object):
     missions.
     """
 
-    def __init__(self, vehicle_id):
+    @classmethod
+    def create(cls, import_manager, waypoint_type, vehicle_id, location, **kwargs):
+        """
+        Create a `Waypoint` object.
+
+        The given `import_manager` should be an `Import_Manager` that allows us
+        to import the waypoint classes. The `waypoint_type` is a value from the
+        `Waypoint_Type` enum that specifies the type of the waypoint. The other
+        arguments are passed on to the initialization of the `Waypoint`.
+        """
+
+        waypoint_class_name = "Waypoint_{}".format(waypoint_type.name.title())
+        waypoint_class = import_manager.load_class(waypoint_class_name,
+                                                   relative_module="waypoint")
+
+        return waypoint_class(vehicle_id, location, **kwargs)
+
+    def __init__(self, vehicle_id, location, **kwargs):
         """
         Create a waypoint object. The `vehicle_id` is an integer identifier for
         the vehicle who should run the mission in which the waypoints are added.
+
+        The `location` is a Location object, as a reference for the waypoint.
+        Most likely, the waypoint takes place here, but `Waypoint` subclasses
+        may also do something else with it, e.g., create a range of waypoints,
+        or it may ignore it. Additional arguments may be provided for certain
+        `Waypoint` subclasses; other classes must ignore them.
         """
 
         self._vehicle_id = vehicle_id
+        self._location = location
 
     @property
     def name(self):
@@ -31,7 +55,19 @@ class Waypoint(object):
 
     @property
     def vehicle_id(self):
+        """
+        Retrieve the vehicle identifier.
+        """
+
         return self._vehicle_id
+
+    @property
+    def location(self):
+        """
+        Retrieve the waypoint location.
+        """
+
+        return self._location
 
     def get_points(self):
         """

--- a/waypoint/Waypoint.py
+++ b/waypoint/Waypoint.py
@@ -1,0 +1,45 @@
+from enum import IntEnum
+
+class Waypoint_Type(IntEnum):
+    HOME = 1
+    PASS = 2
+    WAIT = 3
+
+class Waypoint(object):
+    """
+    An object that generates waypoints. This can be used when creating certain
+    missions.
+    """
+
+    def __init__(self, vehicle_id):
+        """
+        Create a waypoint object. The `vehicle_id` is an integer identifier for
+        the vehicle who should run the mission in which the waypoints are added.
+        """
+
+        self._vehicle_id = vehicle_id
+
+    @property
+    def name(self):
+        """
+        Retrieve the name of the waypoint object.
+
+        This should be a `Waypoint_Type` enum value.
+        """
+
+        raise NotImplementedError("Subclasses must implement `name`")
+
+    @property
+    def vehicle_id(self):
+        return self._vehicle_id
+
+    def get_points(self):
+        """
+        Retrieve the waypoints that can be registered in a vehicle.
+
+        This is a list of various values. Supported values are dronekit's
+        Location objects and `None`, which means we wait at the waypoint for
+        an indetermined amount of time.
+        """
+
+        raise NotImplementedError("Subclasses must implement `get_points`")

--- a/waypoint/Waypoint.py
+++ b/waypoint/Waypoint.py
@@ -12,7 +12,8 @@ class Waypoint(object):
     """
 
     @classmethod
-    def create(cls, import_manager, waypoint_type, vehicle_id, location, **kwargs):
+    def create(cls, import_manager, waypoint_type, vehicle_id, geometry,
+               location, **kwargs):
         """
         Create a `Waypoint` object.
 
@@ -26,9 +27,9 @@ class Waypoint(object):
         waypoint_class = import_manager.load_class(waypoint_class_name,
                                                    relative_module="waypoint")
 
-        return waypoint_class(vehicle_id, location, **kwargs)
+        return waypoint_class(vehicle_id, geometry, location, **kwargs)
 
-    def __init__(self, vehicle_id, location, **kwargs):
+    def __init__(self, vehicle_id, geometry, location, **kwargs):
         """
         Create a waypoint object. The `vehicle_id` is an integer identifier for
         the vehicle who should run the mission in which the waypoints are added.
@@ -41,6 +42,7 @@ class Waypoint(object):
         """
 
         self._vehicle_id = vehicle_id
+        self._geometry = geometry
         self._location = location
 
     @property
@@ -79,3 +81,13 @@ class Waypoint(object):
         """
 
         raise NotImplementedError("Subclasses must implement `get_points`")
+
+    def get_required_sensors(self):
+        """
+        Retrieve the list of required sensors that we should wait for when we
+        go to the requested waypoints. Returns `None` if the waypoint requires
+        all sensors (at least when this is enabled), and raises a `RuntimeError`
+        if waiting is not supported by this waypoint.
+        """
+
+        raise RuntimeError("Waypoint does not support waiting for required sensors")

--- a/waypoint/Waypoint_Home.py
+++ b/waypoint/Waypoint_Home.py
@@ -1,0 +1,19 @@
+from Waypoint import Waypoint, Waypoint_Type
+
+class Waypoint_Home(Waypoint):
+    """
+    A waypoint that changes the home location of the vehicle.
+    """
+
+    @property
+    def name(self):
+        return Waypoint_Type.HOME
+
+    def get_points(self):
+        # The home location is not a waypoint.
+        return []
+
+    def update_vehicle(self, vehicle):
+        super(Waypoint_Home, self).update_vehicle(vehicle)
+
+        vehicle.home_location = self._location

--- a/waypoint/Waypoint_Pass.py
+++ b/waypoint/Waypoint_Pass.py
@@ -1,0 +1,14 @@
+from Waypoint import Waypoint, Waypoint_Type
+
+class Waypoint_Pass(Waypoint):
+    """
+    A waypoint that passes through the given waypoint, with no inherent need to
+    stop at that point unless this is necessary during the mission.
+    """
+
+    @property
+    def name(self):
+        return Waypoint_Type.PASS
+
+    def get_points(self):
+        return [self._location]

--- a/waypoint/Waypoint_Wait.py
+++ b/waypoint/Waypoint_Wait.py
@@ -1,0 +1,26 @@
+from Waypoint import Waypoint, Waypoint_Type
+
+class Waypoint_Wait(Waypoint):
+    def __init__(self, vehicle_id, geometry, location, previous_location=None,
+                 wait_id=0, wait_count=1, **kwargs):
+        super(Waypoint_Wait, self).__init__(vehicle_id, geometry, location)
+
+        if previous_location is None:
+            self._previous_location = self._geometry.home_location
+        else:
+            self._previous_location = previous_location
+
+        self._wait_id = wait_id
+        self._wait_count = wait_count
+
+    @property
+    def name(self):
+        return Waypoint_Type.WAIT
+
+    def get_points(self):
+        return self._geometry.get_location_range(self._previous_location,
+                                                 self._location,
+                                                 count=self._wait_count)
+
+    def get_required_sensors(self):
+        return [self._wait_id] if self._wait_id > 0 else None

--- a/waypoint/Waypoint_Wait.py
+++ b/waypoint/Waypoint_Wait.py
@@ -1,6 +1,11 @@
 from Waypoint import Waypoint, Waypoint_Type
 
 class Waypoint_Wait(Waypoint):
+    """
+    A waypoint that waits at specific intervals between the previous location
+    before this waypoint and the waypoint location.
+    """
+
     def __init__(self, vehicle_id, geometry, location, previous_location=None,
                  wait_id=0, wait_count=1, **kwargs):
         super(Waypoint_Wait, self).__init__(vehicle_id, geometry, location)

--- a/waypoint/__init__.py
+++ b/waypoint/__init__.py
@@ -1,0 +1,2 @@
+# Initialize as subpackage
+__all__ = []

--- a/zigbee/specifications.json
+++ b/zigbee/specifications.json
@@ -131,6 +131,10 @@
             "format": "d"
         },
         {
+            "name": "type",
+            "format": "B"
+        },
+        {
             "name": "wait_id",
             "format": "B"
         },


### PR DESCRIPTION
Implement three waypoint types: setting the vehicle's **home location** at the start of the mission, moving it via a waypoint that it is allowed to **pass**, and going to a waypoint to **wait** for certain other vehicles.

These types are shown in the control panel waypoints view and used in the RF sensor mission. The waypoints view was updated to perform more constraint validity, as well as other cleanup to the cell interaction such as keyboard navigation. The planning view generates valid wait type waypoints, but could later maybe provide other information.

The RF sensor mission uses the waypoint types to offload the waypoint generation and deduces whether we should add a wait waypoint to the mission.

Other waypoint types may be added later, and they might be used in other missions to generate patterns such as the fan beam, straight line and calibration cycles. This is not part of this PR, which intends to implement the basic requirements for different waypoint types.
