### PR TITLE
Planning cleanups

### DIFF
--- a/plan_reconstruct.py
+++ b/plan_reconstruct.py
@@ -1,4 +1,5 @@
 # Core imports
+import datetime
 import os
 import sys
 import time
@@ -60,6 +61,11 @@ def iteration_callback(algorithm, data):
     cur_time = data["cur_time"]
     speed = t/float(cur_time)
     print("Iteration {} ({} sec, {} it/s)".format(t, cur_time, speed))
+
+    if speed != 0.0:
+        rate = (algorithm.t_max - t) / speed
+        end_time = datetime.datetime.now() + datetime.timedelta(seconds=rate)
+        print("{} seconds remaining, ETA: {}".format(rate, end_time))
 
     Feasible = data["feasible"]
     Objectives = data["objectives"]

--- a/planning/Algorithm.py
+++ b/planning/Algorithm.py
@@ -249,7 +249,7 @@ class NSGA(Algorithm):
         return self.crowding_distance(Rk)
 
     def get_name(self):
-        return "NSGA"
+        return "NSGA-II"
 
 class SMS_EMOA(Algorithm):
     def hypervolume_contribution(self, Rk):

--- a/planning/Collision_Avoidance.py
+++ b/planning/Collision_Avoidance.py
@@ -128,7 +128,9 @@ class Collision_Avoidance(Location_Proxy):
             self._vehicle_syncs = dict([(i, set([i])) for i in self._vehicles])
 
             for i, home in enumerate(home_locations):
-                self._vehicle_routes[i+1] = [(int(home[0]), int(home[1]))]
+                home = (int(home[0]), int(home[1]))
+                home = tuple(np.clip(home, (0, 0), self._network_size))
+                self._vehicle_routes[i+1] = [home]
                 self._memory_map.set(home, Collision_Type.VEHICLE)
 
         self._current_vehicle = vehicle

--- a/planning/Collision_Avoidance.py
+++ b/planning/Collision_Avoidance.py
@@ -128,7 +128,7 @@ class Collision_Avoidance(Location_Proxy):
             self._vehicle_syncs = dict([(i, set([i])) for i in self._vehicles])
 
             for i, home in enumerate(home_locations):
-                self._vehicle_routes[i+1] = [home]
+                self._vehicle_routes[i+1] = [(int(home[0]), int(home[1]))]
                 self._memory_map.set(home, Collision_Type.VEHICLE)
 
         self._current_vehicle = vehicle

--- a/planning/Greedy_Assignment.py
+++ b/planning/Greedy_Assignment.py
@@ -91,7 +91,7 @@ class Greedy_Assignment(object):
 
         self._collision_avoider.reset()
 
-        positions = np.array(positions_pairs)
+        positions = np.array(positions_pairs, dtype=np.int)
         current_positions = list(self._home_locations)
 
         assignment = dict([

--- a/planning/Problem.py
+++ b/planning/Problem.py
@@ -80,7 +80,7 @@ class Problem(object):
         # type, which ones are integer and which ones are reals.
         if len(self.domain) > 2:
             # Draw random binary values.
-            v[self._bool_indices] = np.random.random_integers(0, 1, size=len(self._bool_indices[0]))
+            v[self._bool_indices] = np.random.randint(2, size=len(self._bool_indices[0]))
 
         return v
 


### PR DESCRIPTION
These are changes that were made in relation to experiments that were performed with the planning algorithms, but were distinct from the code for the experiments themselves. There are not that many changes, which are mostly fixes for deprecations or corner cases.

The other (larger) changes are related to the command-line planning runner, namely to give an indication of when it finishes. The control panel change supports importing the unordered JSON dumps that the runner generates into the waypoints view, such that we can run the greedy assignment and collision avoidance afterward again.

No new tests are provided because these changes mostly affect parts that are either not covered by the current tests (control panel, planning runner) or are small-scale changes that do not influence the normal mode of operation. The original tests are sufficient.
