### PR TITLE
Travis: Require trusty for newer g++ version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
+sudo: required
+dist: trusty
 language: python
-python:
-    - "2.7.9"
 addons:
     apt:
         packages:


### PR DESCRIPTION
A new LIRC version has components that require C++11, so we need a newer version than 4.6 provided by Ubuntu precise (12.04 LTS). Thus use Ubuntu trusty (14.04 LTS) which uses g++ 4.8. Also remove the python 2.7.9 requirement since trusty provides python 2.7.10.
