### PR TITLE
Unit tests: Prevent AssertionError log spam

### DIFF
--- a/core/Thread_Manager.py
+++ b/core/Thread_Manager.py
@@ -38,8 +38,10 @@ class Thread_Manager(object):
         """
 
         # Log the destroy call only if it is being called from an except clause
-        # to prevent "None" spam in the logs.
-        if sys.exc_info() != (None, None, None):
+        # to prevent "None" spam in the logs. Also exclude assertion errors 
+        # from tests since those result in a test failure anyway.
+        exception = sys.exc_info()[0]
+        if exception is not None and not issubclass(exception, AssertionError):
             self.log("main thread")
 
         for threadable in self._threads.values():

--- a/tests/core_thread_manager.py
+++ b/tests/core_thread_manager.py
@@ -118,7 +118,16 @@ class TestCoreThreadManager(ThreadableTestCase):
     def test_destroy_log(self, log_mock):
         # The `destroy` method does not call `log` outside an exception context.
         self.thread_manager.destroy()
-        self.assertEqual(log_mock.call_count, 0)
+        log_mock.assert_not_called()
+
+        # The `destroy` method does not call `log` when a test failure is 
+        # handled.
+        try:
+            raise AssertionError("Test failure must not be logged")
+        except:
+            self.thread_manager.destroy()
+
+        log_mock.assert_not_called()
 
         # If `destroy` is called in an exception handling block, `log` is called.
         try:


### PR DESCRIPTION
Do not log `AssertionError` exceptions raised from `Threadable` objects,
since those are already shown by the test runner and the logs add
nothing to this.
