### PR TITLE
Infrared sensor: implement powering off the vehicle

### DIFF
--- a/control/Infrared_Sensor.py
+++ b/control/Infrared_Sensor.py
@@ -122,6 +122,11 @@ class Infrared_Sensor(Threadable):
             super(Infrared_Sensor, self).interrupt()
 
     def _handle_lirc_code(self, data):
+        """
+        Handle incoming LIRC events by triggering a callback function
+        if a registered button is clicked.
+        """
+
         if data is not None:
             button = data[0]
             self._previous_button = button

--- a/control/remotes/Sony_RM-SRB5.lircrc
+++ b/control/remotes/Sony_RM-SRB5.lircrc
@@ -43,3 +43,9 @@ begin
     config = right
     repeat = 1
 end
+
+begin
+    button = sleep
+    prog = mobile-radio-tomography
+    config = poweroff
+end

--- a/mission_basic.py
+++ b/mission_basic.py
@@ -5,6 +5,7 @@ Based on mission_basic.py in Dronekit, but supports other vehicle types as well.
 Documentation for the source is provided at http://python.dronekit.io/examples/mission_basic.html
 """
 
+import subprocess
 import sys
 import traceback
 
@@ -44,6 +45,7 @@ class Setup(object):
             infrared_sensor.register("start", self.enable)
             infrared_sensor.register("pause", self.monitor.pause)
             infrared_sensor.register("stop", self._infrared_disable)
+            infrared_sensor.register("poweroff", self._infrared_poweroff)
             infrared_sensor.activate()
         else:
             self.activated = True
@@ -114,6 +116,10 @@ class Setup(object):
 
     def _infrared_disable(self):
         self.environment.thread_manager.interrupt("infrared_sensor")
+
+    def _infrared_poweroff(self):
+        self.environment.thread_manager.interrupt("infrared_sensor")
+        subprocess.Popen(["poweroff"])
 
 def main(argv):
     arguments = Arguments("settings.json", argv)

--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -199,7 +199,7 @@
                 "help": "Registered buttons",
                 "type": "list",
                 "subtype": "string",
-                "default": ["start", "pause", "stop", "up", "down", "left", "right"]
+                "default": ["start", "pause", "stop", "up", "down", "left", "right", "poweroff"]
             },
             "wait_delay": {
                 "help": "Delay in seconds for the infrared sensor thread",


### PR DESCRIPTION
This patch allows us to power off the vehicles using a button (in our
case, the "sleep" button) on the remote control. It is mainly useful so
we do not have to connect with Ethernet and SSH into the device every
time to power it off, which also makes it possible to swap batteries
faster.
