### PR TITLE
Sequential packets

### DIFF
--- a/settings/defaults.json
+++ b/settings/defaults.json
@@ -98,7 +98,7 @@
                 "help": "Frequency in seconds to retry sending a setting packet to a vehicle",
                 "type": "float",
                 "min": 0.0,
-                "default": 0.3
+                "default": 0.1
             }
         }
     },
@@ -115,7 +115,7 @@
                 "help": "Frequency in seconds to retry sending a waypoint packet to a vehicle",
                 "type": "float",
                 "min": 0.0,
-                "default": 0.3
+                "default": 0.1
             }
         }
     },

--- a/tests/zigbee_rf_sensor.py
+++ b/tests/zigbee_rf_sensor.py
@@ -215,8 +215,19 @@ class TestZigBeeRFSensor(ZigBeeRFSensorTestCase):
 
     def test_discover(self):
         # Providing an invalid callback raises an exception.
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegexp(TypeError, "callback is not callable"):
             self.rf_sensor.discover(None)
+
+        callback_mock = MagicMock()
+
+        # Providing invalid required sensors raises an exception.
+        with self.assertRaisesRegexp(TypeError, "must be a `set`"):
+            self.rf_sensor.discover(callback_mock, required_sensors=2)
+
+        # Providing an set of required sensors that cannot be discovered raises 
+        # an exception.
+        with self.assertRaisesRegexp(ValueError, "only contain vehicle sensors"):
+            self.rf_sensor.discover(callback_mock, required_sensors=set([0]))
 
     def test_setup(self):
         # Verify that the interface requires subclasses to implement

--- a/tests/zigbee_rf_sensor_physical_texas_instruments.py
+++ b/tests/zigbee_rf_sensor_physical_texas_instruments.py
@@ -74,6 +74,18 @@ class TestZigBeeRFSensorPhysicalTexasInstruments(ZigBeeRFSensorTestCase, USBMana
             self.assertEqual(packet.get("sensor_id"), to_id)
             self.assertEqual(to, to_id)
 
+        # Requiring only a specific set of one sensor causes a packet to be 
+        # sent to only that sensor.
+        send_tx_frame_mock.reset_mock()
+        self.rf_sensor.discover(MagicMock(), required_sensors=set([1]))
+
+        self.assertEqual(send_tx_frame_mock.call_count, 1)
+        packet, to = send_tx_frame_mock.call_args[0]
+        self.assertIsInstance(packet, Packet)
+        self.assertEqual(packet.get("specification"), "ping_pong")
+        self.assertEqual(packet.get("sensor_id"), 1)
+        self.assertEqual(to, 1)
+
     @patch.object(time, "sleep")
     def test_setup(self, sleep_mock):
         connection_mock = MagicMock()

--- a/zigbee/RF_Sensor.py
+++ b/zigbee/RF_Sensor.py
@@ -229,16 +229,25 @@ class RF_Sensor(Threadable):
                 "to": to
             })
 
-    def discover(self, callback):
+    def discover(self, callback, required_sensors=None):
         """
-        Discover all RF sensors in the network. The `callback` function is
-        called when an RF sensor reports its identity.
+        Discover RF sensors in the network. The `callback` callable function is
+        called when an RF sensor reports its identity. The `required_sensors`
+        set indicates which sensors should be discovered; if it is not
+        provided, then all RF sensors are discovered. Note that discovery may
+        fail due to interference or disabled sensors.
 
         Classes that inherit this base class must extend this method.
         """
 
         if not hasattr(callback, "__call__"):
             raise TypeError("Provided discovery callback is not callable")
+
+        if isinstance(required_sensors, set):
+            if not required_sensors.issubset(range(1, self._number_of_sensors + 1)):
+                raise ValueError("Provided required sensors may only contain vehicle sensors")
+        elif required_sensors is not None:
+            raise TypeError("Provided required sensors must be a `set`")
 
     def _setup(self):
         raise NotImplementedError("Subclasses must implement `_setup()`")

--- a/zigbee/RF_Sensor_Physical.py
+++ b/zigbee/RF_Sensor_Physical.py
@@ -41,15 +41,18 @@ class RF_Sensor_Physical(RF_Sensor):
         self._ntp = NTP(self)
         self._ntp_delay = self._settings.get("ntp_delay")
 
-    def discover(self, callback):
+    def discover(self, callback, required_sensors=None):
         """
-        Discover all RF sensors in the network. The `callback` function is
-        called when an RF sensor reports its identity.
+        Discover RF sensors in the network. The `callback` callable function is
+        called when an RF sensor reports its identity. The `required_sensors`
+        set indicates which sensors should be discovered; if it is not
+        provided, then all RF sensors are discovered.
 
         Classes that inherit this base class must extend this method.
         """
 
-        super(RF_Sensor_Physical, self).discover(callback)
+        super(RF_Sensor_Physical, self).discover(callback,
+                                                 required_sensors=required_sensors)
 
         self._discovery_callback = callback
 

--- a/zigbee/RF_Sensor_Physical_Texas_Instruments.py
+++ b/zigbee/RF_Sensor_Physical_Texas_Instruments.py
@@ -95,16 +95,24 @@ class RF_Sensor_Physical_Texas_Instruments(RF_Sensor_Physical):
 
         super(RF_Sensor_Physical_Texas_Instruments, self).start()
 
-    def discover(self, callback):
+    def discover(self, callback, required_sensors=None):
         """
-        Discover all RF sensors in the network. The `callback` function is
-        called when an RF sensor reports its identity.
+        Discover RF sensors in the network. The `callback` callable function is
+        called when an RF sensor reports its identity. The `required_sensors`
+        set indicates which sensors should be discovered; if it is not
+        provided, then all RF sensors are discovered.
+
+        CC2530 devices are discovered if they respond to packets.
         """
 
-        super(RF_Sensor_Physical_Texas_Instruments, self).discover(callback)
+        super(RF_Sensor_Physical_Texas_Instruments, self).discover(callback,
+                                                                   required_sensors=required_sensors)
 
-        # Send a ping/pong packet to all sensors in the network.
-        for index in xrange(1, self._number_of_sensors + 1):
+        if required_sensors is None:
+            required_sensors = set(range(1, self._number_of_sensors + 1))
+
+        # Send a ping/pong packet to the sensors in the network.
+        for index in required_sensors:
             packet = Packet()
             packet.set("specification", "ping_pong")
             packet.set("sensor_id", index)

--- a/zigbee/RF_Sensor_Physical_XBee.py
+++ b/zigbee/RF_Sensor_Physical_XBee.py
@@ -105,13 +105,15 @@ class RF_Sensor_Physical_XBee(RF_Sensor_Physical):
 
         self._packets = {}
 
-    def discover(self, callback):
+    def discover(self, callback, required_sensors=None):
         """
-        Discover all RF sensors in the network. The `callback` function is
-        called when an RF sensor reports its identity.
+        Discover RF sensors in the network. The `callback` callable function is
+        called when an RF sensor reports its identity. The other arguments are
+        ignored; all XBee devices are discovered if possible.
         """
 
-        super(RF_Sensor_Physical_XBee, self).discover(callback)
+        super(RF_Sensor_Physical_XBee, self).discover(callback,
+                                                      required_sensors=required_sensors)
 
         self._sensor.send("at", command="ND")
 


### PR DESCRIPTION
- Send packets for waypoints and settings sequentially instead of causing interference by sending them to all vehicles at the same time.
- Discover specific sensors that have not yet joined in the devices view.
