### PR TITLE
Setting simplification

### DIFF
--- a/mission/Mission_RF_Sensor.py
+++ b/mission/Mission_RF_Sensor.py
@@ -178,16 +178,18 @@ class Mission_RF_Sensor(Mission_Auto):
         wait_count = data["wait_count"]
         wait_waypoint = data["wait_waypoint"]
 
-        # Create location waypoints based on the type and additional data. 
-        # `add_waypoint` handles any further conversions of the provided 
-        # waypoints from the `Waypoint` object.
+        # Create the waypoint based on the type, location and additional data, 
+        # such as wait for vehicle ID, wait count, and wait waypoint for wait 
+        # type waypoints, and home direction (sent in "union" of wait ID) for 
+        # the home waypoint.
         location = self.geometry.make_location(latitude, longitude, altitude)
         waypoint = Waypoint.create(self.environment.get_import_manager(),
                                    waypoint_type, self._rf_sensor.id,
                                    self.geometry, location,
                                    previous_location=self._point,
                                    wait_id=wait_id, wait_count=wait_count,
-                                   wait_waypoint=wait_waypoint)
+                                   wait_waypoint=wait_waypoint,
+                                   home_direction=wait_id)
 
         # Retrieve the required sensors. A return value `None` actually means 
         # we want to wait for all other sensors, while an exception means we do 
@@ -205,6 +207,8 @@ class Mission_RF_Sensor(Mission_Auto):
             else:
                 other_waypoint_id = -1
 
+            # `add_waypoint` handles any further conversions of the provided 
+            # waypoints from the `Waypoint` object.
             self.add_waypoint(point, wait=wait,
                               required_sensors=required_sensors,
                               wait_waypoint=other_waypoint_id)

--- a/planning/Greedy_Assignment.py
+++ b/planning/Greedy_Assignment.py
@@ -46,7 +46,7 @@ class Greedy_Assignment(object):
         self._number_of_waits = None
 
     def _add_waypoint(self, vehicle, position, waypoint_type, wait_id=0,
-                      wait_count=1, wait_waypoint=-1):
+                      wait_count=1, wait_waypoint=-1, home_direction=0):
         """
         Create a waypoint for the vehicle with sensor ID `vehicle`, based on
         the given coordinate tuple `position` and additional type-specific
@@ -55,10 +55,16 @@ class Greedy_Assignment(object):
         The assignment can be altered to add different waypoint types using the
         `waypoint_type` keyword argument, which expects a `Waypoint_Type` enum
         value. For wait types, `wait_id`, `wait_count` and `wait_waypoint`
-        integers are accepted if they are known at this point.
+        integers are allowed, and for the home waypoint type, `home_direction`
+        is allowed.
         """
 
         if self._export:
+            # The wait ID and home direction share a "union" in a the exported 
+            # waypoints lists.
+            if waypoint_type == Waypoint_Type.HOME:
+                wait_id = home_direction
+
             waypoint = list(position) + [
                 0, waypoint_type, wait_id, wait_count, wait_waypoint
             ]
@@ -67,7 +73,8 @@ class Greedy_Assignment(object):
             waypoint = Waypoint.create(self._import_manager, waypoint_type,
                                        vehicle, self._geometry, location,
                                        wait_id=wait_id, wait_count=wait_count,
-                                       wait_waypoint=wait_waypoint)
+                                       wait_waypoint=wait_waypoint,
+                                       home_direction=home_direction)
 
         self._assignment[vehicle].append(waypoint)
 
@@ -221,7 +228,8 @@ class Greedy_Assignment(object):
             (i, []) for i in range(1, self._number_of_vehicles + 1)
         ])
         for vehicle, home_location in enumerate(self._current_positions):
-            self._add_waypoint(vehicle + 1, home_location, Waypoint_Type.HOME)
+            self._add_waypoint(vehicle + 1, home_location, Waypoint_Type.HOME,
+                               home_direction=self._current_directions[vehicle])
 
         total_distance = 0
 

--- a/tests/mission_rf_sensor.py
+++ b/tests/mission_rf_sensor.py
@@ -2,6 +2,7 @@ import json
 from mock import mock_open, patch
 from dronekit import LocationLocal
 from ..environment.Environment import Environment
+from ..location.Line_Follower import Line_Follower_Direction
 from ..mission.Mission_RF_Sensor import Mission_RF_Sensor
 from ..vehicle.Robot_Vehicle import Robot_State
 from ..waypoint.Waypoint import Waypoint_Type
@@ -235,11 +236,13 @@ class TestMissionRFSensor(EnvironmentTestCase):
         with patch('sys.stdout'):
             self.mission.setup()
 
-        home_location = LocationLocal(5.0, 15.0, 0.0)
+        home_location = LocationLocal(5.0, 1.0, 0.0)
         self.enqueue_mock.reset_mock()
-        self._send_waypoint_add(0, 5.0, 15.0, type=Waypoint_Type.HOME)
+        self._send_waypoint_add(0, 5.0, 1.0, type=Waypoint_Type.HOME, wait_id=2)
         self.assertEqual(self.mission.next_index, 1)
         self.assertEqual(self.vehicle.home_location, home_location)
+        self.assertEqual(self.vehicle._home_direction,
+                         Line_Follower_Direction.DOWN)
         self.assertEqual(self.mission._point, home_location)
         self.assertEqual(self.vehicle._waypoints, [])
 

--- a/tests/planning_greedy_assignment.py
+++ b/tests/planning_greedy_assignment.py
@@ -16,7 +16,7 @@ class TestPlanningGreedyAssignment(SettingsTestCase):
         ])
         settings = self.arguments.get_settings("planning_assignment")
         settings.set("vehicle_home_locations", [[0, 0], [0, 19]])
-        settings.set("vehicle_home_directions", [0, 0])
+        settings.set("vehicle_home_directions", [0, 3])
 
         self.geometry = Geometry_Grid()
         self.import_manager = Import_Manager()
@@ -54,7 +54,7 @@ class TestPlanningGreedyAssignment(SettingsTestCase):
             [19, 1, 0, wait, 2, 1, 4]
         ])
         self.assertEqual(assignment[2], [
-            [0, 19, 0, Waypoint_Type.HOME, 0, 1, -1],
+            [0, 19, 0, Waypoint_Type.HOME, 3, 1, -1],
             [2, 19, 0, wait, 1, 1, 0], [4, 19, 0, wait, 1, 1, 1],
             [5, 16, 0, wait, 1, 1, 2], [1, 16, 0, wait, 1, 1, 3],
             [4, 18, 0, wait, 1, 1, 4]

--- a/tests/vehicle.py
+++ b/tests/vehicle.py
@@ -1,3 +1,4 @@
+import math
 from mock import patch, MagicMock, PropertyMock
 from dronekit import LocationLocal, LocationGlobal, LocationGlobalRelative, VehicleMode
 from ..bench.Method_Coverage import covers
@@ -132,6 +133,11 @@ class TestVehicle(VehicleTestCase):
     def test_home_location(self):
         new_location = LocationGlobal(1.0, 2.0, 3.0)
         self.vehicle.home_location = new_location
+        self.assertEqual(self.vehicle._home_location, new_location)
+
+    def test_set_home_state(self):
+        new_location = LocationGlobal(1.0, 2.0, 3.0)
+        self.vehicle.set_home_state(new_location, yaw=math.pi)
         self.assertEqual(self.vehicle._home_location, new_location)
 
     def test_add_attribute_listener(self):

--- a/tests/vehicle_robot_vehicle.py
+++ b/tests/vehicle_robot_vehicle.py
@@ -39,6 +39,8 @@ class TestVehicleRobotVehicle(RobotVehicleTestCase):
     def test_initialization(self):
         self.assertEqual(self.vehicle.arguments, self.arguments)
         self.assertEqual(self.vehicle._home_location, (0, 0))
+        self.assertEqual(self.vehicle._home_direction,
+                         Line_Follower_Direction.UP)
         self.assertEqual(self.vehicle._direction, Line_Follower_Direction.UP)
         self.assertIsInstance(self.vehicle._state, Robot_State)
         self.assertEqual(self.vehicle._state.name, "intersection")
@@ -69,6 +71,14 @@ class TestVehicleRobotVehicle(RobotVehicleTestCase):
 
             self.vehicle.add_waypoint(LocationGlobal(4.0, 8.0, 6.4))
             self.assertEqual(self.vehicle._waypoints, [(4, 8)])
+
+    def test_set_home_state(self):
+        self.vehicle.set_home_state(LocationLocal(1.0, 2.0, 4.0), yaw=math.pi)
+        self.assertEqual(self.vehicle._home_location, (1, 2))
+        self.assertEqual(self.vehicle.home_location,
+                         LocationLocal(1.0, 2.0, 0.0))
+        self.assertEqual(self.vehicle._home_direction,
+                         Line_Follower_Direction.DOWN)
 
     def test_setup(self):
         self.vehicle.setup()

--- a/tests/vehicle_robot_vehicle_arduino_full.py
+++ b/tests/vehicle_robot_vehicle_arduino_full.py
@@ -1,3 +1,4 @@
+import math
 import serial
 from dronekit import LocationLocal
 from mock import patch
@@ -81,9 +82,19 @@ class TestVehicleRobotVehicleArduinoFull(RobotVehicleTestCase):
     def test_home_location(self):
         loc = LocationLocal(5.0, 6.0, 0.0)
         self.vehicle.home_location = loc
-        # We send a "set home location" message to the Arduino.
+        # We send a "set home location" command to the Arduino.
         self.assertEqual(self._ttl_device.readline(), "HOME 5 6 S\n")
         self.assertEqual(self.vehicle.home_location, loc)
+
+    def test_set_home_state(self):
+        loc = LocationLocal(7.0, 8.0, 0.0)
+        self.vehicle.set_home_state(loc, yaw=0.5*math.pi)
+        # We send a "set home location" command with the new location and 
+        # direction to the Arduino.
+        self.assertEqual(self._ttl_device.readline(), "HOME 7 8 E\n")
+        self.assertEqual(self.vehicle.home_location, loc)
+        self.assertEqual(self.vehicle._home_direction,
+                         Line_Follower_Direction.RIGHT)
 
     def test_get_direction(self):
         cases = [

--- a/tests/waypoint_home.py
+++ b/tests/waypoint_home.py
@@ -1,6 +1,7 @@
 from dronekit import LocationLocal
 from mock import MagicMock
 from ..geometry.Geometry import Geometry
+from ..location.Line_Follower import Line_Follower_Direction
 from ..vehicle.Vehicle import Vehicle
 from ..waypoint.Waypoint import Waypoint_Type
 from ..waypoint.Waypoint_Home import Waypoint_Home
@@ -12,10 +13,15 @@ class TestWaypointHome(LocationTestCase):
 
         self.geometry = Geometry()
         self.location = LocationLocal(1.2, 3.4, -5.6)
-        self.waypoint = Waypoint_Home(1, self.geometry, self.location)
+        self.direction = Line_Follower_Direction.DOWN
+        self.waypoint = Waypoint_Home(1, self.geometry, self.location,
+                                      home_direction=self.direction)
 
     def test_name(self):
         self.assertEqual(self.waypoint.name, Waypoint_Type.HOME)
+
+    def test_home_direction(self):
+        self.assertEqual(self.waypoint.home_direction, self.direction)
 
     def test_get_points(self):
         self.assertEqual(self.waypoint.get_points(), [])
@@ -27,4 +33,6 @@ class TestWaypointHome(LocationTestCase):
 
         vehicle_mock = MagicMock(spec_set=Vehicle)
         self.waypoint.update_vehicle(vehicle_mock)
-        self.assertEqual(vehicle_mock.home_location, self.location)
+        yaw = self.direction.yaw
+        vehicle_mock.set_home_state.assert_called_once_with(self.location,
+                                                            yaw=yaw)

--- a/tests/zigbee_rf_sensor_physical_texas_instruments.py
+++ b/tests/zigbee_rf_sensor_physical_texas_instruments.py
@@ -45,6 +45,23 @@ class TestZigBeeRFSensorPhysicalTexasInstruments(ZigBeeRFSensorTestCase, USBMana
         self.assertEqual(self.rf_sensor._pins["cts_pin"], self.settings.get("cts_pin"))
         self.assertEqual(self.rf_sensor._pins["reset_pin"], self.settings.get("reset_pin"))
 
+    @patch("socket.gethostname")
+    def test_identify(self, host_name_mock):
+        # Ignore any changes to settings, assuming we left it default.
+        self.rf_sensor._id = 0
+
+        # A host name that does not match the pattern keeps the default 
+        # identity, without raising any exceptions.
+        host_name_mock.configure_mock(return_value="researcher-laptop")
+        self.rf_sensor._identify()
+        self.assertEqual(self.rf_sensor.id, 0)
+
+        # A host name that matches the pattern sets the ID correspondingly.
+        host_name_mock.configure_mock(return_value="raspberry-pi-4")
+        self.rf_sensor._identify()
+        self.assertEqual(self.rf_sensor.id, 4)
+        self.assertEqual(self.rf_sensor._scheduler.id, 4)
+
     def test_type(self):
         # The `type` property must be implemented and correct.
         self.assertEqual(self.rf_sensor.type, "rf_sensor_physical_texas_instruments")

--- a/vehicle/Robot_Vehicle.py
+++ b/vehicle/Robot_Vehicle.py
@@ -64,7 +64,8 @@ class Robot_Vehicle(Vehicle):
         # The starting direction of the robot. The robot should be aligned with 
         # this direction to begin with.
         direction = self.settings.get("home_direction")
-        self._direction = Line_Follower_Direction(direction)
+        self._home_direction = Line_Follower_Direction(direction)
+        self._direction = self._home_direction
 
         self._line_follower = None
         self._setup_line_follower(import_manager, thread_manager, usb_manager)
@@ -217,6 +218,10 @@ class Robot_Vehicle(Vehicle):
     def home_location(self, value):
         self._home_location = self._geometry.get_coordinates(value)[:2]
         self.notify_attribute_listeners("home_location", self.home_location)
+
+    def set_home_state(self, position, yaw=0.0):
+        self._home_direction = Line_Follower_Direction.from_yaw(yaw)
+        self.home_location = position
 
     @property
     def mode(self):

--- a/vehicle/Robot_Vehicle_Arduino_Full.py
+++ b/vehicle/Robot_Vehicle_Arduino_Full.py
@@ -49,7 +49,7 @@ class Robot_Vehicle_Arduino_Full(Robot_Vehicle_Arduino):
         # Only use this when starting.
         home_north = int(self._home_location[0])
         home_east = int(self._home_location[1])
-        home_direction = self._get_zumo_direction(self._direction)
+        home_direction = self._get_zumo_direction(self._home_direction)
         self._serial_connection.write("HOME {} {} {}\n".format(home_north, home_east, home_direction))
 
     def _update_network_dimensions(self):

--- a/vehicle/Vehicle.py
+++ b/vehicle/Vehicle.py
@@ -95,6 +95,19 @@ class Vehicle(Threadable):
         self._home_location = copy.copy(position)
         self.notify_attribute_listeners('home_location', self._home_location)
 
+    def set_home_state(self, position, yaw=0.0):
+        """
+        Change the home location to another `Location` object `position` and
+        the expected yaw attitude to another `yaw`.
+
+        For vehicles that make use of a home attitude, either to know their
+        initial orientation compared to the geometry or to know how to orient
+        themselves upon returning to its home location, this method allows one
+        to keep track of both the home location and the yaw.
+        """
+
+        self.home_location = position
+
     @property
     def mode(self):
         """

--- a/waypoint/Waypoint_Home.py
+++ b/waypoint/Waypoint_Home.py
@@ -1,3 +1,4 @@
+from ..location.Line_Follower import Line_Follower_Direction
 from Waypoint import Waypoint, Waypoint_Type
 
 class Waypoint_Home(Waypoint):
@@ -5,9 +6,19 @@ class Waypoint_Home(Waypoint):
     A waypoint that changes the home location of the vehicle.
     """
 
+    def __init__(self, vehicle_id, geometry, location, home_direction=0,
+                 **kwargs):
+        super(Waypoint_Home, self).__init__(vehicle_id, geometry, location)
+
+        self._home_direction = Line_Follower_Direction(home_direction)
+
     @property
     def name(self):
         return Waypoint_Type.HOME
+
+    @property
+    def home_direction(self):
+        return self._home_direction
 
     def get_points(self):
         # The home location is not a waypoint.
@@ -16,4 +27,5 @@ class Waypoint_Home(Waypoint):
     def update_vehicle(self, vehicle):
         super(Waypoint_Home, self).update_vehicle(vehicle)
 
-        vehicle.home_location = self._location
+        # Update the home location and home direction yaw of the vehicle.
+        vehicle.set_home_state(self._location, yaw=self._home_direction.yaw)

--- a/zigbee/RF_Sensor_Physical_Texas_Instruments.py
+++ b/zigbee/RF_Sensor_Physical_Texas_Instruments.py
@@ -1,5 +1,6 @@
 # Core imports
 import random
+import socket
 import struct
 import time
 
@@ -44,7 +45,9 @@ class RF_Sensor_Physical_Texas_Instruments(RF_Sensor_Physical):
                                                                    valid_callback,
                                                                    usb_manager=usb_manager)
 
+        self._identify()
         self._address = str(self._id)
+
         self._joined = True
         self._polling_time = 0.0
 
@@ -65,6 +68,22 @@ class RF_Sensor_Physical_Texas_Instruments(RF_Sensor_Physical):
             "cts_pin": self._settings.get("cts_pin"),
             "reset_pin": self._settings.get("reset_pin")
         }
+
+    def _identify(self):
+        """
+        Update the identifier of the sensor.
+
+        If the sensor ID is unchanged from the default, then the host name of
+        the current device is used to determine the ID. The host name should
+        end with a dash an a numerical identifier, which matches the actual ID.
+        """
+
+        if self._id == 0:
+            try:
+                self._id = int(socket.gethostname().split("-")[-1])
+                self._scheduler.id = self._id
+            except ValueError:
+                pass
 
     @property
     def type(self):


### PR DESCRIPTION
Reduce the per-vehicle settings so that we can easily send the same settings to all vehicles.
- Infer the RF sensor ID from the host name of the Raspberry Pi.
- Pass along the home direction in the home waypoint packet (from planning) to the vehicles (and the Arduino).
