### PR TITLE
Environment: Enforce paired synchronization

### DIFF
--- a/control_panel/Control_Panel_Controller.py
+++ b/control_panel/Control_Panel_Controller.py
@@ -119,8 +119,8 @@ class Control_Panel_Controller(object):
             callback = self._packet_callbacks[specification]
             callback(packet)
 
-    def _location_valid(self, other_valid=None, other_id=None, other_index=None):
-        return False
+    def _location_valid(self, request):
+        return False, False
 
     def add_packet_callback(self, specification, callback):
         """

--- a/rf_sensor.py
+++ b/rf_sensor.py
@@ -14,8 +14,8 @@ def get_location():
 def receive_packet(packet):
     print("Received packet: {}".format(packet.get_all()))
 
-def location_valid(other_valid=None, other_id=None, other_index=None):
-    return True
+def location_valid(request):
+    return True, True
 
 def main(argv):
     import_manager = Import_Manager()

--- a/tests/mission_fan.py
+++ b/tests/mission_fan.py
@@ -140,10 +140,11 @@ class TestMissionFan(EnvironmentTestCase):
 
         other_id = self.rf_sensor.id + 1
         self.environment.set_waypoint_valid()
-        self.assertTrue(self.environment.location_valid())
-        self.assertTrue(self.environment.location_valid(other_valid=True,
-                                                        other_id=other_id,
-                                                        other_index=1))
+        self.assertTrue(self.location_valid(True, other_id=other_id))
+        self.assertTrue(self.location_valid(False, other_id=other_id,
+                                            other_index=1, other_valid=True,
+                                            other_valid_pair=True))
+        self.assertTrue(self.location_valid(True, other_id=other_id))
 
         with patch('sys.stdout'):
             self.mission.check_waypoint()

--- a/tests/mission_fan_straight.py
+++ b/tests/mission_fan_straight.py
@@ -124,10 +124,11 @@ class TestMissionFanStraight(EnvironmentTestCase):
 
         other_id = self.rf_sensor.id + 1
         self.environment.set_waypoint_valid()
-        self.assertTrue(self.environment.location_valid())
-        self.assertTrue(self.environment.location_valid(other_valid=True,
-                                                        other_id=other_id,
-                                                        other_index=1))
+        self.assertTrue(self.location_valid(True, other_id=other_id))
+        self.assertTrue(self.location_valid(False, other_id=other_id,
+                                            other_index=1, other_valid=True,
+                                            other_valid_pair=True))
+        self.assertTrue(self.location_valid(True, other_id=other_id))
 
         with patch('sys.stdout'):
             self.mission.check_waypoint()

--- a/tests/mission_rf_sensor.py
+++ b/tests/mission_rf_sensor.py
@@ -389,10 +389,10 @@ class TestMissionRFSensor(EnvironmentTestCase):
         self.assertTrue(self.vehicle.is_wait())
 
         other_id = self.rf_sensor.id + 1
-        self.assertTrue(self.environment.location_valid())
-        self.assertTrue(self.environment.location_valid(other_valid=True,
-                                                        other_id=other_id,
-                                                        other_index=1))
+        self.assertTrue(self.location_valid(False, other_id=other_id,
+                                            other_index=1, other_valid=True,
+                                            other_valid_pair=True))
+        self.assertTrue(self.location_valid(True, other_id=other_id))
         with patch('sys.stdout'):
             self.assertTrue(self.mission.check_waypoint())
 
@@ -415,8 +415,9 @@ class TestMissionRFSensor(EnvironmentTestCase):
         self.assertTrue(self.vehicle.is_wait())
 
         other_id = self.rf_sensor.id + 1
-        self.assertTrue(self.environment.location_valid(other_valid=True,
-                                                        other_id=other_id,
-                                                        other_index=3))
+        self.assertTrue(self.location_valid(True, other_id=other_id,
+                                            other_index=3, other_valid=True,
+                                            other_valid_pair=True))
+        self.assertTrue(self.location_valid(False, other_id=other_id))
         with patch('sys.stdout'):
             self.assertTrue(self.mission.check_waypoint())

--- a/tests/zigbee_rf_sensor.py
+++ b/tests/zigbee_rf_sensor.py
@@ -31,7 +31,7 @@ class ZigBeeRFSensorTestCase(SettingsTestCase, ZigBeePacketTestCase):
         self.thread_manager = Thread_Manager()
         self.location_callback = MagicMock(return_value=((0, 0), 0))
         self.receive_callback = MagicMock()
-        self.valid_callback = MagicMock(return_value=True)
+        self.valid_callback = MagicMock(return_value=(True, True))
 
     def _create_sensor(self, sensor_type, **kwargs):
         """
@@ -296,7 +296,7 @@ class TestZigBeeRFSensor(ZigBeeRFSensorTestCase):
 
     @patch.object(RF_Sensor, "_send_tx_frame")
     def test_send(self, send_tx_frame_mock):
-        self.rf_sensor._packets.put(self.rf_sensor._create_rssi_broadcast_packet())
+        self.rf_sensor._packets.put(self.rf_sensor._create_rssi_broadcast_packet(2))
 
         # If the current time is inside an allocated slot, then packets
         # may be sent.
@@ -376,7 +376,7 @@ class TestZigBeeRFSensor(ZigBeeRFSensorTestCase):
             self.rf_sensor._receive(packet=self.packet)
 
     def test_create_rssi_broadcast_packet(self):
-        packet = self.rf_sensor._create_rssi_broadcast_packet()
+        packet = self.rf_sensor._create_rssi_broadcast_packet(2)
 
         self.assertIsInstance(packet, Packet)
         self.assertEqual(packet.get("specification"), "rssi_broadcast")
@@ -388,7 +388,7 @@ class TestZigBeeRFSensor(ZigBeeRFSensorTestCase):
         self.assertAlmostEqual(packet.get("timestamp"), time.time(), delta=0.1)
 
     def test_create_rssi_ground_station_packet(self):
-        rssi_broadcast_packet = self.rf_sensor._create_rssi_broadcast_packet()
+        rssi_broadcast_packet = self.rf_sensor._create_rssi_broadcast_packet(2)
         packet = self.rf_sensor._create_rssi_ground_station_packet(rssi_broadcast_packet)
 
         self.assertIsInstance(packet, Packet)

--- a/tests/zigbee_rf_sensor_physical.py
+++ b/tests/zigbee_rf_sensor_physical.py
@@ -105,7 +105,7 @@ class TestZigBeeRFSensorPhysical(ZigBeeRFSensorTestCase):
 
         timestamp = self.rf_sensor._scheduler.timestamp
 
-        packet = self.rf_sensor._create_rssi_broadcast_packet()
+        packet = self.rf_sensor._create_rssi_broadcast_packet(2)
         ground_station_packet = self.rf_sensor._process_rssi_broadcast_packet(packet)
 
         # The scheduler's timestamp must be updated.

--- a/tests/zigbee_rf_sensor_physical_texas_instruments.py
+++ b/tests/zigbee_rf_sensor_physical_texas_instruments.py
@@ -279,7 +279,7 @@ class TestZigBeeRFSensorPhysicalTexasInstruments(ZigBeeRFSensorTestCase, USBMana
         with self.assertRaises(TypeError):
             self.rf_sensor._process_rssi_broadcast_packet(Packet())
 
-        packet = self.rf_sensor._create_rssi_broadcast_packet()
+        packet = self.rf_sensor._create_rssi_broadcast_packet(2)
 
         self.rf_sensor._process_rssi_broadcast_packet(packet, rssi=42)
 

--- a/tests/zigbee_rf_sensor_physical_xbee.py
+++ b/tests/zigbee_rf_sensor_physical_xbee.py
@@ -170,11 +170,11 @@ class TestZigBeeRFSensorPhysicalXBee(ZigBeeRFSensorTestCase, USBManagerTestCase)
     def test_send(self):
         # Create two dummy packets, one of them having an associated RSSI 
         # value.
-        first_packet = self.rf_sensor._create_rssi_broadcast_packet()
+        first_packet = self.rf_sensor._create_rssi_broadcast_packet(2)
         first_packet.set("rssi", 42)
         self.rf_sensor._packets[0] = first_packet
 
-        second_packet = self.rf_sensor._create_rssi_broadcast_packet()
+        second_packet = self.rf_sensor._create_rssi_broadcast_packet(2)
         self.rf_sensor._packets[1] = second_packet
 
         # If the current time is inside an allocated slot, then packets
@@ -263,6 +263,7 @@ class TestZigBeeRFSensorPhysicalXBee(ZigBeeRFSensorTestCase, USBManagerTestCase)
         self.packet.set("latitude", 123456789.12)
         self.packet.set("longitude", 123459678.34)
         self.packet.set("valid", True)
+        self.packet.set("valid_pair", True)
         self.packet.set("waypoint_index", 1)
         self.packet.set("sensor_id", 2)
         self.packet.set("timestamp", time.time())
@@ -296,7 +297,7 @@ class TestZigBeeRFSensorPhysicalXBee(ZigBeeRFSensorTestCase, USBManagerTestCase)
         # AT response DB packets should be processed. The parsed RSSI value
         # should be placed in the original packet in the data object.
         self.rf_sensor._packets = {
-            1: self.rf_sensor._create_rssi_broadcast_packet()
+            1: self.rf_sensor._create_rssi_broadcast_packet(2)
         }
         raw_packet = {
             "id": "at_response",

--- a/tests/zigbee_rf_sensor_simulator.py
+++ b/tests/zigbee_rf_sensor_simulator.py
@@ -135,7 +135,7 @@ class TestZigBeeRFSensorSimulator(ZigBeeRFSensorTestCase):
 
         timestamp = self.rf_sensor._scheduler.timestamp
 
-        packet = self.rf_sensor._create_rssi_broadcast_packet()
+        packet = self.rf_sensor._create_rssi_broadcast_packet(2)
         self.rf_sensor._receive(packet=packet)
 
         # The receive callback must be called with the packet.

--- a/zigbee/RF_Sensor_Physical_XBee.py
+++ b/zigbee/RF_Sensor_Physical_XBee.py
@@ -185,7 +185,6 @@ class RF_Sensor_Physical_XBee(RF_Sensor_Physical):
         """
 
         # Create and send the RSSI broadcast packets.
-        packet = self._create_rssi_broadcast_packet()
         for to_id in xrange(1, self._number_of_sensors + 1):
             if not self._scheduler.in_slot:
                 return
@@ -193,6 +192,7 @@ class RF_Sensor_Physical_XBee(RF_Sensor_Physical):
             if to_id == self._id:
                 continue
 
+            packet = self._create_rssi_broadcast_packet(to_id)
             self._send_tx_frame(packet, to_id)
 
         # Send collected packets to the ground station. Only send completed 

--- a/zigbee/specifications.json
+++ b/zigbee/specifications.json
@@ -19,6 +19,10 @@
             "format": "?"
         },
         {
+            "name": "valid_pair",
+            "format": "B"
+        },
+        {
             "name": "waypoint_index",
             "format": "i"
         },


### PR DESCRIPTION
A vehicle should not start moving while the other vehicle is not yet
notified of it completing the measurements. To ensure that both know
when this has happened, enforce a "paired" bidirectional measurement
with another flag in the broadcast specification.

Also ensure "catching up" on waypoint synchronization works.
